### PR TITLE
Refactor signatures for the `collect` combinators

### DIFF
--- a/src/either.ts
+++ b/src/either.ts
@@ -494,13 +494,13 @@ export namespace Either {
      */
     export function collect<T extends readonly Either<any, any>[]>(
         eithers: T,
-    ): Either<LeftT<T[number]>, RightsT<T>> {
+    ): Either<LeftT<T[number]>, { [K in keyof T]: RightT<T[K]> }> {
         return go(function* () {
-            const results = new Array(eithers.length);
+            const results: unknown[] = new Array(eithers.length);
             for (const [idx, either] of eithers.entries()) {
                 results[idx] = yield* either;
             }
-            return results as RightsT<T>;
+            return results as { [K in keyof T]: RightT<T[K]> };
         });
     }
 
@@ -516,7 +516,7 @@ export namespace Either {
             for (const [key, either] of Object.entries(eithers)) {
                 results[key] = yield* either;
             }
-            return results as RightsT<T>;
+            return results as { [K in keyof T]: RightT<T[K]> };
         });
     }
 
@@ -780,23 +780,4 @@ export namespace Either {
     // prettier-ignore
     export type RightT<T extends Either<any, any>> = 
         [T] extends [Either<any, infer B>] ? B : never;
-
-    /**
-     * Given an Array, a tuple literal, a Record, or an object literal of
-     * `Either` types, map over the structure to return an equivalent structure
-     * of the `Right` types.
-     *
-     * ```ts
-     * type T0 = [Either<1, 2>, Either<3, 4>, Either<5, 6>];
-     * type T1 = RightsT<T0>; // [2, 4, 6]
-     *
-     * type T2 = { x: Either<1, 2>, y: Either<3, 4>, z: Either<5, 6> };
-     * type T3 = RightsT<T2>; // { x: 2, y: 4, z: 6 }
-     * ```
-     */
-    export type RightsT<
-        T extends readonly Either<any, any>[] | Record<any, Either<any, any>>,
-    > = {
-        [K in keyof T]: [T[K]] extends [Either<any, infer B>] ? B : never;
-    };
 }

--- a/src/eval.ts
+++ b/src/eval.ts
@@ -349,13 +349,13 @@ export class Eval<out A> {
      */
     static collect<T extends readonly Eval<any>[]>(
         evals: T,
-    ): Eval<Eval.ResultsT<T>> {
+    ): Eval<{ [K in keyof T]: Eval.ResultT<T[K]> }> {
         return Eval.go(function* () {
-            const results = new Array(evals.length);
+            const results: unknown[] = new Array(evals.length);
             for (const [idx, ev] of evals.entries()) {
                 results[idx] = yield* ev;
             }
-            return results as Eval.ResultsT<T>;
+            return results as { [K in keyof T]: Eval.ResultT<T[K]> };
         });
     }
 
@@ -371,7 +371,7 @@ export class Eval<out A> {
             for (const [key, ev] of Object.entries(evals)) {
                 results[key] = yield* ev;
             }
-            return results as Eval.ResultsT<T>;
+            return results as { [K in keyof T]: Eval.ResultT<T[K]> };
         });
     }
 
@@ -495,25 +495,6 @@ export namespace Eval {
     // prettier-ignore
     export type ResultT<T extends Eval<any>> = 
         T extends Eval<infer A> ? A : never;
-
-    /**
-     * Given an Array, a tuple literal, a Record, or an object literal of Eval
-     * types, map over the structure to return an equivalent structure of the
-     * result types.
-     *
-     * ```ts
-     * type T0 = [Eval<1>, Eval<2>, Eval<3>];
-     * type T1 = Eval.ResultsT<T0>; // [1, 2, 3]
-     *
-     * type T2 = { x: Eval<1>, y: Eval<2>, z: Eval<3> };
-     * type T3 = Eval.ResultsT<T2>; // { x: 1, y: 2, z: 3 }
-     * ```
-     */
-    export type ResultsT<
-        T extends readonly Eval<any>[] | Record<any, Eval<any>>,
-    > = {
-        [K in keyof T]: T[K] extends Eval<infer A> ? A : never;
-    };
 }
 
 type Instr = Instr.Now | Instr.FlatMap | Instr.Once | Instr.Always;

--- a/src/ior.ts
+++ b/src/ior.ts
@@ -540,110 +540,16 @@ export namespace Ior {
      * collect the right-hand values in an Array or a tuple literal,
      * respectively.
      */
-    export function collect<E extends Semigroup<E>, A0, A1>(
-        iors: readonly [Ior<E, A0>, Ior<E, A1>],
-    ): Ior<E, [A0, A1]>;
-
-    export function collect<E extends Semigroup<E>, A0, A1, A2>(
-        iors: readonly [Ior<E, A0>, Ior<E, A1>, Ior<E, A2>],
-    ): Ior<E, [A0, A1, A2]>;
-
-    export function collect<E extends Semigroup<E>, A0, A1, A2, A3>(
-        iors: readonly [Ior<E, A0>, Ior<E, A1>, Ior<E, A2>, Ior<E, A3>],
-    ): Ior<E, [A0, A1, A2, A3]>;
-
-    export function collect<E extends Semigroup<E>, A0, A1, A2, A3, A4>(
-        iors: readonly [
-            Ior<E, A0>,
-            Ior<E, A1>,
-            Ior<E, A2>,
-            Ior<E, A3>,
-            Ior<E, A4>,
-        ],
-    ): Ior<E, [A0, A1, A2, A3, A4]>;
-
-    export function collect<E extends Semigroup<E>, A0, A1, A2, A3, A4, A5>(
-        iors: readonly [
-            Ior<E, A0>,
-            Ior<E, A1>,
-            Ior<E, A2>,
-            Ior<E, A3>,
-            Ior<E, A4>,
-            Ior<E, A5>,
-        ],
-    ): Ior<E, [A0, A1, A2, A3, A4, A5]>;
-
-    export function collect<E extends Semigroup<E>, A0, A1, A2, A3, A4, A5, A6>(
-        iors: readonly [
-            Ior<E, A0>,
-            Ior<E, A1>,
-            Ior<E, A2>,
-            Ior<E, A3>,
-            Ior<E, A4>,
-            Ior<E, A5>,
-            Ior<E, A6>,
-        ],
-    ): Ior<E, [A0, A1, A2, A3, A4, A5, A6]>;
-
-    // prettier-ignore
-    export function collect<E extends Semigroup<E>, A0, A1, A2, A3, A4, A5, A6, A7>(
-        iors: readonly [
-            Ior<E, A0>,
-            Ior<E, A1>,
-            Ior<E, A2>,
-            Ior<E, A3>,
-            Ior<E, A4>,
-            Ior<E, A5>,
-            Ior<E, A6>,
-            Ior<E, A7>,
-        ],
-    ): Ior<E, [A0, A1, A2, A3, A4, A5, A6, A7]>;
-
-    // prettier-ignore
-    export function collect<E extends Semigroup<E>, A0, A1, A2, A3, A4, A5, A6, A7, A8>(
-        iors: readonly [
-            Ior<E, A0>,
-            Ior<E, A1>,
-            Ior<E, A2>,
-            Ior<E, A3>,
-            Ior<E, A4>,
-            Ior<E, A5>,
-            Ior<E, A6>,
-            Ior<E, A7>,
-            Ior<E, A8>,
-        ],
-    ): Ior<E, [A0, A1, A2, A3, A4, A5, A6, A7, A8]>;
-
-    // prettier-ignore
-    export function collect<E extends Semigroup<E>, A0, A1, A2, A3, A4, A5, A6, A7, A8, A9>(
-        iors: readonly [
-            Ior<E, A0>,
-            Ior<E, A1>,
-            Ior<E, A2>,
-            Ior<E, A3>,
-            Ior<E, A4>,
-            Ior<E, A5>,
-            Ior<E, A6>,
-            Ior<E, A7>,
-            Ior<E, A8>,
-            Ior<E, A9>,
-        ],
-    ): Ior<E, [A0, A1, A2, A3, A4, A5, A6, A7, A8, A9]>;
-
-    export function collect<E extends Semigroup<E>, A>(
-        iors: readonly Ior<E, A>[],
-    ): Ior<E, A[]>;
-
-    export function collect<E extends Semigroup<E>, A>(
-        iors: readonly Ior<E, A>[],
-    ): Ior<E, A[]> {
+    export function collect<T extends readonly Ior<Semigroup<any>, any>[]>(
+        iors: T,
+    ): Ior<LeftT<T[number]>, { [K in keyof T]: RightT<T[K]> }> {
         return go(function* () {
-            const results: A[] = new Array(iors.length);
+            const results: unknown[] = new Array(iors.length);
             for (const [idx, ior] of iors.entries()) {
                 results[idx] = yield* ior;
             }
             return results;
-        });
+        }) as Ior<LeftT<T[number]>, { [K in keyof T]: RightT<T[K]> }>;
     }
 
     /**
@@ -981,4 +887,18 @@ export namespace Ior {
             return (yield [this]) as B;
         }
     }
+
+    /**
+     * Extract the left-hand type `A` from the type `Ior<A, B>`.
+     */
+    // prettier-ignore
+    export type LeftT<T extends Ior<any, any>> =
+        [T] extends [Ior<infer A, any>] ? A : never;
+
+    /**
+     * Extract the right-hand type `B` from the type `Ior<A, B>`.
+     */
+    // prettier-ignore
+    export type RightT<T extends Ior<any, any>> =
+        [T] extends [Ior<any, infer B>] ? B : never;
 }

--- a/src/maybe.ts
+++ b/src/maybe.ts
@@ -480,13 +480,13 @@ export namespace Maybe {
      */
     export function collect<T extends readonly Maybe<any>[]>(
         maybes: T,
-    ): Maybe<JustsT<T>> {
+    ): Maybe<{ [K in keyof T]: JustT<T[K]> }> {
         return go(function* () {
-            const results = new Array(maybes.length);
+            const results: unknown[] = new Array(maybes.length);
             for (const [idx, maybe] of maybes.entries()) {
                 results[idx] = yield* maybe;
             }
-            return results as JustsT<T>;
+            return results as { [K in keyof T]: JustT<T[K]> };
         });
     }
 
@@ -502,7 +502,7 @@ export namespace Maybe {
             for (const [key, maybe] of Object.entries(maybes)) {
                 results[key] = yield* maybe;
             }
-            return results as JustsT<T>;
+            return results as { [K in keyof T]: JustT<T[K]> };
         });
     }
 
@@ -719,23 +719,4 @@ export namespace Maybe {
     // prettier-ignore
     export type JustT<T extends Maybe<any>> =
         T extends Maybe<infer A> ? A : never;
-
-    /**
-     * Given an Array, a tuple literal, a Record, or an object literal of Maybe
-     * types, map over the structure to return an equivalent structure of the
-     * `Just` types.
-     *
-     * ```ts
-     * type T0 = [Maybe<1>, Maybe<2>, Maybe<3>];
-     * type T1 = JustsT<T0>; // [1, 2, 3]
-     *
-     * type T2 = { x: Maybe<1>, y: Maybe<2>, z: Maybe<3> };
-     * type T3 = JustsT<T2>; // { x: 1, y: 2, z: 3 }
-     * ```
-     */
-    export type JustsT<
-        T extends readonly Maybe<any>[] | Record<any, Maybe<any>>,
-    > = {
-        [K in keyof T]: T[K] extends Maybe<infer A> ? A : never;
-    };
 }

--- a/src/validated.ts
+++ b/src/validated.ts
@@ -337,111 +337,12 @@ export namespace Validated {
      * and collect the `Accepted` values in an Array or a tuple literal,
      * respectively.
      */
-    export function collect<E extends Semigroup<E>, A0, A1>(
-        vtds: readonly [Validated<E, A0>, Validated<E, A1>],
-    ): Validated<E, [A0, A1]>;
-
-    export function collect<E extends Semigroup<E>, A0, A1, A2>(
-        vtds: readonly [Validated<E, A0>, Validated<E, A1>, Validated<E, A2>],
-    ): Validated<E, [A0, A1, A2]>;
-
-    export function collect<E extends Semigroup<E>, A0, A1, A2, A3>(
-        vtds: readonly [
-            Validated<E, A0>,
-            Validated<E, A1>,
-            Validated<E, A2>,
-            Validated<E, A3>,
-        ],
-    ): Validated<E, [A0, A1, A2, A3]>;
-
-    export function collect<E extends Semigroup<E>, A0, A1, A2, A3, A4>(
-        vtds: readonly [
-            Validated<E, A0>,
-            Validated<E, A1>,
-            Validated<E, A2>,
-            Validated<E, A3>,
-            Validated<E, A4>,
-        ],
-    ): Validated<E, [A0, A1, A2, A3, A4]>;
-
-    // prettier-ignore
-    export function collect<E extends Semigroup<E>, A0, A1, A2, A3, A4, A5>(
-        vtds: readonly [
-            Validated<E, A0>,
-            Validated<E, A1>,
-            Validated<E, A2>,
-            Validated<E, A3>,
-            Validated<E, A4>,
-            Validated<E, A5>,
-        ],
-    ): Validated<E, [A0, A1, A2, A3, A4, A5]>;
-
-    // prettier-ignore
-    export function collect<E extends Semigroup<E>, A0, A1, A2, A3, A4, A5, A6>(
-        vtds: readonly [
-            Validated<E, A0>,
-            Validated<E, A1>,
-            Validated<E, A2>,
-            Validated<E, A3>,
-            Validated<E, A4>,
-            Validated<E, A5>,
-            Validated<E, A6>,
-        ],
-    ): Validated<E, [A0, A1, A2, A3, A4, A5, A6]>;
-
-    // prettier-ignore
-    export function collect<E extends Semigroup<E>, A0, A1, A2, A3, A4, A5, A6, A7>(
-        vtds: readonly [
-            Validated<E, A0>,
-            Validated<E, A1>,
-            Validated<E, A2>,
-            Validated<E, A3>,
-            Validated<E, A4>,
-            Validated<E, A5>,
-            Validated<E, A6>,
-            Validated<E, A7>,
-        ],
-    ): Validated<E, [A0, A1, A2, A3, A4, A5, A6, A7]>;
-
-    // prettier-ignore
-    export function collect<E extends Semigroup<E>, A0, A1, A2, A3, A4, A5, A6, A7, A8>(
-        vtds: readonly [
-            Validated<E, A0>,
-            Validated<E, A1>,
-            Validated<E, A2>,
-            Validated<E, A3>,
-            Validated<E, A4>,
-            Validated<E, A5>,
-            Validated<E, A6>,
-            Validated<E, A7>,
-            Validated<E, A8>,
-        ],
-    ): Validated<E, [A0, A1, A2, A3, A4, A5, A6, A7, A8]>;
-
-    // prettier-ignore
-    export function collect<E extends Semigroup<E>, A0, A1, A2, A3, A4, A5, A6, A7, A8, A9>(
-        vtds: readonly [
-            Validated<E, A0>,
-            Validated<E, A1>,
-            Validated<E, A2>,
-            Validated<E, A3>,
-            Validated<E, A4>,
-            Validated<E, A5>,
-            Validated<E, A6>,
-            Validated<E, A7>,
-            Validated<E, A8>,
-            Validated<E, A9>,
-        ],
-    ): Validated<E, [A0, A1, A2, A3, A4, A5, A6, A7, A8, A9]>;
-
-    export function collect<E extends Semigroup<E>, A>(
-        vtds: readonly Validated<E, A>[],
-    ): Validated<E, A[]>;
-
-    export function collect<E extends Semigroup<E>, A>(
-        vtds: readonly Validated<E, A>[],
-    ): Validated<E, A[]> {
-        let acc = accept<A[], E>(new Array(vtds.length));
+    export function collect<
+        T extends readonly Validated<Semigroup<any>, any>[],
+    >(
+        vtds: T,
+    ): Validated<DisputedT<T[number]>, { [K in keyof T]: AcceptedT<T[K]> }> {
+        let acc = accept<any, any>(new Array(vtds.length));
         for (const [idx, vtd] of vtds.entries()) {
             acc = acc.zipWith(vtd, (results, x) => {
                 results[idx] = x;
@@ -631,4 +532,18 @@ export namespace Validated {
             this.val = val;
         }
     }
+
+    /**
+     * Extract the `Disputed` type `E` from the type `Validated<E, A>`.
+     */
+    // prettier-ignore
+    export type DisputedT<T extends Validated<any, any>> =
+        [T] extends [Validated<infer E, any>] ? E : never;
+
+    /**
+     * Extract the `Accepted` type `A` from the type `Validated<E, A>`.
+     */
+    // prettier-ignore
+    export type AcceptedT<T extends Validated<any, any>> =
+        [T] extends [Validated<any, infer A>] ? A : never;
 }

--- a/test/validated_test.ts
+++ b/test/validated_test.ts
@@ -28,16 +28,28 @@ describe("Validated", () => {
     });
 
     specify("Validated.collect", () => {
-        const t0 = Validated.collect([mk("D", sa, _2), mk("D", sc, _4)]);
+        const t0 = Validated.collect([
+            mk("D", sa, _2),
+            mk("D", sc, _4),
+        ] as const);
         assert.deepEqual(t0, Validated.dispute(cmb(sa, sc)));
 
-        const t1 = Validated.collect([mk("D", sa, _2), mk("A", sc, _4)]);
+        const t1 = Validated.collect([
+            mk("D", sa, _2),
+            mk("A", sc, _4),
+        ] as const);
         assert.deepEqual(t1, Validated.dispute(sa));
 
-        const t2 = Validated.collect([mk("A", sa, _2), mk("D", sc, _4)]);
+        const t2 = Validated.collect([
+            mk("A", sa, _2),
+            mk("D", sc, _4),
+        ] as const);
         assert.deepEqual(t2, Validated.dispute(sc));
 
-        const t3 = Validated.collect([mk("A", sa, _2), mk("A", sc, _4)]);
+        const t3 = Validated.collect([
+            mk("A", sa, _2),
+            mk("A", sc, _4),
+        ] as const);
         assert.deepEqual(t3, Validated.accept([_2, _4] as const));
     });
 


### PR DESCRIPTION
- Simplify the `collect` signatures for `Ior` and `Validated`
- Remove the mapped type aliases for `Either`, `Eval`, and `Maybe`