### PR TITLE
Introduce the `gather` combinators for `Ior` and `Validated`

### DIFF
--- a/src/ior.ts
+++ b/src/ior.ts
@@ -187,6 +187,7 @@
  * required for left-hand values so they may accumulate.
  *
  * - `collect` turns an Array or a tuple literal of Iors inside out.
+ * - `gather` turns a Record or an object literal of Iors inside out.
  *
  * Additionally, the `reduce` function reduces a finite Iterable from left to
  * right in the context of `Ior`. This is useful for mapping, filtering, and
@@ -550,6 +551,22 @@ export namespace Ior {
             }
             return results;
         }) as Ior<LeftT<T[number]>, { [K in keyof T]: RightT<T[K]> }>;
+    }
+
+    /**
+     * Evaluate the Iors in a Record or an object literal and collect the
+     * right-hand values in a Record or an object literal, respectively.
+     */
+    export function gather<T extends Record<any, Ior<Semigroup<any>, any>>>(
+        iors: T,
+    ): Ior<LeftT<T[keyof T]>, { [K in keyof T]: RightT<T[K]> }> {
+        return Ior.go(function* () {
+            const results: Record<any, unknown> = {};
+            for (const [key, ior] of Object.entries(iors)) {
+                results[key] = yield* ior;
+            }
+            return results;
+        }) as Ior<LeftT<T[keyof T]>, { [K in keyof T]: RightT<T[K]> }>;
     }
 
     /**

--- a/src/validated.ts
+++ b/src/validated.ts
@@ -135,9 +135,12 @@
  * Validateds. Sometimes, a collection of Validateds must be turned "inside out"
  * into a Validated that contains an equivalent collection of `Accepted` values.
  *
- * The `collect` method will traverse an Array of Validateds to extract the
- * `Accepted` values. If any Validated in the Array is `Disputed`, the traversal
- * is halted and `Disputed` values begin accumulating instead.
+ * These methods will traverse a collection of Validateds to extract the
+ * `Accepted` values. If any Validated in the collection is `Disputed`, the
+ * traversal is halted and `Disputed` values begin accumulating instead.
+ *
+ * - `collect` turns an Array or a tuple literal of Validateds inside out.
+ * - `gather` turns a Record or an object literal of Validateds inside out.
  *
  * ## Examples
  *
@@ -346,6 +349,25 @@ export namespace Validated {
         for (const [idx, vtd] of vtds.entries()) {
             acc = acc.zipWith(vtd, (results, x) => {
                 results[idx] = x;
+                return results;
+            });
+        }
+        return acc;
+    }
+
+    /**
+     * Evaluate the Validateds in a Record or an object literal and collect the
+     * `Accepted` values in a Record or an object literal, respectively.
+     */
+    export function gather<
+        T extends Record<string, Validated<Semigroup<any>, any>>,
+    >(
+        vtds: T,
+    ): Validated<DisputedT<T[keyof T]>, { [K in keyof T]: AcceptedT<T[K]> }> {
+        let acc = accept<any, any>({});
+        for (const [key, vtd] of Object.entries(vtds)) {
+            acc = acc.zipWith(vtd, (results, x) => {
+                results[key as keyof T] = x;
                 return results;
             });
         }

--- a/test/ior_test.ts
+++ b/test/ior_test.ts
@@ -99,6 +99,11 @@ describe("Ior", () => {
         assert.deepEqual(t0, Ior.both(cmb(sa, sc), [_2, _4] as const));
     });
 
+    specify("Ior.gather", () => {
+        const t0 = Ior.gather({ x: mk("B", sa, _2), y: mk("B", sc, _4) });
+        assert.deepEqual(t0, Ior.both(cmb(sa, sc), { x: _2, y: _4 }));
+    });
+
     specify("Ior.goAsync", async () => {
         const t0 = await Ior.goAsync(async function* () {
             const x = yield* await mkA("L", sa, _2);

--- a/test/validated_test.ts
+++ b/test/validated_test.ts
@@ -53,6 +53,32 @@ describe("Validated", () => {
         assert.deepEqual(t3, Validated.accept([_2, _4] as const));
     });
 
+    specify("Validated.gather", () => {
+        const t0 = Validated.gather({
+            x: mk("D", sa, _2),
+            y: mk("D", sc, _4),
+        });
+        assert.deepEqual(t0, Validated.dispute(cmb(sa, sc)));
+
+        const t1 = Validated.gather({
+            x: mk("D", sa, _2),
+            y: mk("A", sc, _4),
+        });
+        assert.deepEqual(t1, Validated.dispute(sa));
+
+        const t2 = Validated.gather({
+            x: mk("A", sa, _2),
+            y: mk("D", sc, _4),
+        });
+        assert.deepEqual(t2, Validated.dispute(sc));
+
+        const t3 = Validated.gather({
+            x: mk("A", sa, _2),
+            y: mk("A", sc, _4),
+        });
+        assert.deepEqual(t3, Validated.accept({ x: _2, y: _4 }));
+    });
+
     specify("#[Eq.eq]", () => {
         fc.assert(
             fc.property(arbNum(), arbNum(), (x, y) => {


### PR DESCRIPTION
This introduces the `gather` combinator for the `Ior` and `Validated` types. This combinator was previously omitted due to type level constraints, but this implementation provides a (mostly) type-safe solution.

The main caveat is TypeScript's eagerness to widen the `Semigroup` types, which may create an invalid `Semigroup` instance at runtime. This can be avoided by being diligent about annotating types, particularly function return types and non-trivial variable declarations.