### PR TITLE
Fix flaky arbitrary property generation for the `id` function test

### DIFF
--- a/test/fn_test.ts
+++ b/test/fn_test.ts
@@ -5,9 +5,10 @@ import { id, negate } from "../src/fn.js";
 describe("Functions", () => {
     specify("id", () => {
         fc.assert(
-            fc.property(fc.anything(), (x) => {
-                assert.strictEqual(id(x), x);
-            }),
+            fc.property(
+                fc.anything().filter((x) => !Number.isNaN(x)),
+                (x) => assert.strictEqual(id(x), x),
+            ),
         );
     });
 


### PR DESCRIPTION
The test for `id` uses fast-check to generate arbitrary properties, and could potentially generate `NaN` as a property. `NaN` is not strictly equal to itself (using `===`), which could cause the test to fail. This applies a filter to the arbitrary property generation to disallow `NaN`.