### PR TITLE
Update the `.gitignore` file

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,4 +1,56 @@
-.vscode
+# Build
 dist
-node_modules
 site
+
+# Dependency directories
+node_modules
+jspm_packages
+
+# Logs
+logs
+*.log
+npm-debug.log*
+yarn-debug.log*
+yarn-error.log*
+lerna-debug.log*
+.pnpm-debug.log*
+
+# Diagnostic reports (https://nodejs.org/api/report.html)
+report.[0-9]*.[0-9]*.[0-9]*.[0-9]*.json
+
+# Runtime data
+pids
+*.pid
+*.seed
+*.pid.lock
+
+# TypeScript cache
+*.tsbuildinfo
+
+# Optional npm cache directory
+.npm
+
+# Optional eslint cache
+.eslintcache
+
+# Optional REPL history
+.node_repl_history
+
+# Output of 'npm pack'
+*.tgz
+
+# Yarn Integrity file
+.yarn-integrity
+
+# dotenv environment variable files
+.env
+.env.development.local
+.env.test.local
+.env.production.local
+.env.local
+
+# VSCode settings directory
+.vscode
+
+# VSCode versions used for testing VSCode extensions
+.vscode-test

--- a/package.json
+++ b/package.json
@@ -46,8 +46,8 @@
     "scripts": {
         "clean": "npx rimraf ./dist",
         "lint": "npx eslint --ext .ts .",
-        "prettier:check": "npx prettier --check --ignore-path ./gitignore .",
-        "prettier:write": "npx prettier --write --ignore-path ./gitignore .",
+        "prettier:check": "npx prettier --check --ignore-path ./.gitignore .",
+        "prettier:write": "npx prettier --write --ignore-path ./.gitignore .",
         "pretest": "npm run lint && npm run prettier:check",
         "test": "npx mocha",
         "prebuild:dist": "npm run clean",


### PR DESCRIPTION
- Add to the list of ignored paths
- Fix a broken path to the `.gitignore` file for the Prettier `--ignore-path` command-line option