### PR TITLE
Refactor the internal behavior of generator comprehensions

### DIFF
--- a/src/either.ts
+++ b/src/either.ts
@@ -456,13 +456,13 @@ export namespace Either {
     /**
      * Construct an Either using a generator comprehension.
      */
-    export function go<T extends [Either<any, any>], A>(
-        f: () => Generator<T, A, any>,
-    ): Either<LeftT<T[0]>, A> {
+    export function go<T extends Either<any, any>, A>(
+        f: () => Generator<T, A, unknown>,
+    ): Either<LeftT<T>, A> {
         const gen = f();
         let nxt = gen.next();
         while (!nxt.done) {
-            const either = nxt.value[0];
+            const either = nxt.value;
             if (either.isRight()) {
                 nxt = gen.next(either.val);
             } else {
@@ -526,13 +526,13 @@ export namespace Either {
      * Construct a Promise that fulfills with an Either using an async generator
      * comprehension.
      */
-    export async function goAsync<T extends [Either<any, any>], A>(
-        f: () => AsyncGenerator<T, A, any>,
-    ): Promise<Either<LeftT<T[0]>, A>> {
+    export async function goAsync<T extends Either<any, any>, A>(
+        f: () => AsyncGenerator<T, A, unknown>,
+    ): Promise<Either<LeftT<T>, A>> {
         const gen = f();
         let nxt = await gen.next();
         while (!nxt.done) {
-            const either = nxt.value[0];
+            const either = nxt.value;
             if (either.isRight()) {
                 nxt = await gen.next(either.val);
             } else {
@@ -736,8 +736,8 @@ export namespace Either {
          *
          * @hidden
          */
-        *[Symbol.iterator](): Iterator<[Either<A, never>], never, unknown> {
-            return (yield [this]) as never;
+        *[Symbol.iterator](): Iterator<Either<A, never>, never, unknown> {
+            return (yield this) as never;
         }
     }
 
@@ -764,8 +764,8 @@ export namespace Either {
          *
          * @hidden
          */
-        *[Symbol.iterator](): Iterator<[Either<never, B>], B, unknown> {
-            return (yield [this]) as B;
+        *[Symbol.iterator](): Iterator<Either<never, B>, B, unknown> {
+            return (yield this) as B;
         }
     }
 

--- a/src/eval.ts
+++ b/src/eval.ts
@@ -307,19 +307,19 @@ export class Eval<out A> {
     }
 
     static #step<A>(
-        gen: Iterator<[Eval<any>], A>,
-        nxt: IteratorResult<[Eval<any>], A>,
+        gen: Iterator<Eval<any>, A>,
+        nxt: IteratorResult<Eval<any>, A>,
     ): Eval<A> {
         if (nxt.done) {
             return Eval.now(nxt.value);
         }
-        return nxt.value[0].flatMap((x) => Eval.#step(gen, gen.next(x)));
+        return nxt.value.flatMap((x) => Eval.#step(gen, gen.next(x)));
     }
 
     /**
      * Construct an Eval using a generator comprehension.
      */
-    static go<A>(f: () => Generator<[Eval<any>], A, any>): Eval<A> {
+    static go<A>(f: () => Generator<Eval<any>, A, unknown>): Eval<A> {
         return Eval.defer(() => {
             const gen = f();
             return Eval.#step(gen, gen.next());
@@ -390,8 +390,8 @@ export class Eval<out A> {
      *
      * @hidden
      */
-    *[Symbol.iterator](): Iterator<[Eval<A>], A, unknown> {
-        return (yield [this]) as A;
+    *[Symbol.iterator](): Iterator<Eval<A>, A, unknown> {
+        return (yield this) as A;
     }
 
     /**

--- a/src/ior.ts
+++ b/src/ior.ts
@@ -497,14 +497,14 @@ export namespace Ior {
      * Construct an Ior using a generator comprehension.
      */
     export function go<E extends Semigroup<E>, A>(
-        f: () => Generator<[Ior<E, any>], A, any>,
+        f: () => Generator<Ior<E, any>, A, unknown>,
     ): Ior<E, A> {
         const gen = f();
         let nxt = gen.next();
         let acc: E | undefined;
 
         while (!nxt.done) {
-            const ior = nxt.value[0];
+            const ior = nxt.value;
             if (ior.isRight()) {
                 nxt = gen.next(ior.val);
             } else if (ior.isBoth()) {
@@ -572,14 +572,14 @@ export namespace Ior {
      * comprehension.
      */
     export async function goAsync<E extends Semigroup<E>, A>(
-        f: () => AsyncGenerator<[Ior<E, any>], A, any>,
+        f: () => AsyncGenerator<Ior<E, any>, A, unknown>,
     ): Promise<Ior<E, A>> {
         const gen = f();
         let nxt = await gen.next();
         let acc: E | undefined;
 
         while (!nxt.done) {
-            const ior = nxt.value[0];
+            const ior = nxt.value;
             if (ior.isRight()) {
                 nxt = await gen.next(ior.val);
             } else if (ior.isBoth()) {
@@ -836,8 +836,8 @@ export namespace Ior {
          *
          * @hidden
          */
-        *[Symbol.iterator](): Iterator<[Ior<A, never>], never, unknown> {
-            return (yield [this]) as never;
+        *[Symbol.iterator](): Iterator<Ior<A, never>, never, unknown> {
+            return (yield this) as never;
         }
     }
 
@@ -864,8 +864,8 @@ export namespace Ior {
          *
          * @hidden
          */
-        *[Symbol.iterator](): Iterator<[Ior<never, B>], B, unknown> {
-            return (yield [this]) as B;
+        *[Symbol.iterator](): Iterator<Ior<never, B>, B, unknown> {
+            return (yield this) as B;
         }
     }
 
@@ -879,6 +879,7 @@ export namespace Ior {
         readonly typ = Typ.Both;
 
         readonly fst: A;
+
         readonly snd: B;
 
         get val(): [A, B] {
@@ -898,8 +899,8 @@ export namespace Ior {
          *
          * @hidden
          */
-        *[Symbol.iterator](): Iterator<[Ior<A, B>], B, unknown> {
-            return (yield [this]) as B;
+        *[Symbol.iterator](): Iterator<Ior<A, B>, B, unknown> {
+            return (yield this) as B;
         }
     }
 

--- a/src/maybe.ts
+++ b/src/maybe.ts
@@ -444,11 +444,13 @@ export namespace Maybe {
     /**
      * Construct a Maybe using a generator comprehension.
      */
-    export function go<A>(f: () => Generator<[Maybe<any>], A, any>): Maybe<A> {
+    export function go<A>(
+        f: () => Generator<Maybe<any>, A, unknown>,
+    ): Maybe<A> {
         const gen = f();
         let nxt = gen.next();
         while (!nxt.done) {
-            const maybe = nxt.value[0];
+            const maybe = nxt.value;
             if (maybe.isJust()) {
                 nxt = gen.next(maybe.val);
             } else {
@@ -512,12 +514,12 @@ export namespace Maybe {
      * comprehension.
      */
     export async function goAsync<A>(
-        f: () => AsyncGenerator<[Maybe<any>], A, any>,
+        f: () => AsyncGenerator<Maybe<any>, A, unknown>,
     ): Promise<Maybe<A>> {
         const gen = f();
         let nxt = await gen.next();
         while (!nxt.done) {
-            const maybe = nxt.value[0];
+            const maybe = nxt.value;
             if (maybe.isJust()) {
                 nxt = await gen.next(maybe.val);
             } else {
@@ -676,8 +678,8 @@ export namespace Maybe {
          *
          * @hidden
          */
-        *[Symbol.iterator](): Iterator<[Maybe<never>], never, unknown> {
-            return (yield [this]) as never;
+        *[Symbol.iterator](): Iterator<Maybe<never>, never, unknown> {
+            return (yield this) as never;
         }
     }
 
@@ -704,8 +706,8 @@ export namespace Maybe {
          *
          * @hidden
          */
-        *[Symbol.iterator](): Iterator<[Maybe<A>], A, unknown> {
-            return (yield [this]) as A;
+        *[Symbol.iterator](): Iterator<Maybe<A>, A, unknown> {
+            return (yield this) as A;
         }
     }
 


### PR DESCRIPTION
Use the `unknown` type to provide a layer of type safety when accidentally using `yield` inside of generator comprehensions. This moves away from using unary tuples, which eliminates any runtime costs that may have been associated with them.