### PR TITLE
Polish the spacing, formatting, spelling, and grammar in documentation

### DIFF
--- a/src/cmb.ts
+++ b/src/cmb.ts
@@ -29,7 +29,7 @@
  * ## Implementing semigroups
  *
  * -   The `Semigroup` interface provides a contract for implementing
- *     [semigroups][1]. See the documentation for implementation patterns.
+ *     [semigroups]. See the documentation for implementation patterns.
  * -   The `Semigroup` companion namespace provides the unique symbol required
  *     to implement the associated interface.
  *
@@ -59,18 +59,18 @@
  * }
  * ```
  *
- * [1]: https://mathworld.wolfram.com/Semigroup.html
+ * [semigroups]: https://mathworld.wolfram.com/Semigroup.html
  *
  * @module
  */
 
 /**
- * An interface that provides evidence of a [semigroup][1].
+ * An interface that provides evidence of a [semigroup].
  *
  * ## Properties
  *
  * Instances of `Semigroup` must implement an operation that satisfies the
- * [associative property][2], such that:
+ * [associative property], such that:
  *
  * -   `cmb(x, cmb(y, z))` is equivalent to `cmb(cmb(x, y), z)`
  *
@@ -84,7 +84,7 @@
  * existing prototypes.
  *
  * Implementation is implicit and does not require an `implements` clause.
- * TypeScript uses [structural subtyping][3] to determine whether a value
+ * TypeScript uses [structural subtyping] to determine whether a value
  * implements `Semigroup`.
  *
  * ### Conditional implementation
@@ -207,9 +207,9 @@
  *
  * Patching a type in TypeScript requires two steps:
  *
- * 1. an [augmentation][4] for a module or the global scope that patches the
- *    type-level representation; and
- * 1. a concrete implementation for `[Semigroup.cmb]`.
+ * 1.  an [augmentation] for a module or the global scope that patches the
+ *     type-level representation; and
+ * 2.  a concrete implementation for `[Semigroup.cmb]`.
  *
  * The concrete implementation logic is similar to writing a method body for a
  * class or object, and the same practices apply when requiring generic type
@@ -253,10 +253,12 @@
  * };
  * ```
  *
- * [1]: https://mathworld.wolfram.com/Semigroup.html
- * [2]: https://mathworld.wolfram.com/Associative.html
- * [3]: https://www.typescriptlang.org/docs/handbook/type-compatibility.html#site-content
- * [4]: https://www.typescriptlang.org/docs/handbook/declaration-merging.html#module-augmentation
+ * [semigroup]: https://mathworld.wolfram.com/Semigroup.html
+ * [associative property]: https://mathworld.wolfram.com/Associative.html
+ * [structural subypting]:
+ *     https://www.typescriptlang.org/docs/handbook/type-compatibility.html#site-content
+ * [augmentation]:
+ *     https://www.typescriptlang.org/docs/handbook/declaration-merging.html#module-augmentation
  */
 export interface Semigroup<in out A> {
     /**

--- a/src/cmp.ts
+++ b/src/cmp.ts
@@ -30,7 +30,7 @@
  * ## Implementing equivalence relations and total orders
  *
  * -   The `Eq` and `Ord` interfaces provide contracts for implementing
- *     [equivalence relations][1] and [total orders][2], respectively. See their
+ *     [equivalence relations] and [total orders], respectively. See their
  *     respective documentation for implementation patterns.
  * -   The `Eq` and `Ord` companion namespaces provide the unique symbols
  *     required to implement their associated interfaces.
@@ -76,7 +76,7 @@
  *
  * ### Lexicographical comparison
  *
- * Iterables are compared [lexicographically][3], which means:
+ * Iterables are compared [lexicographically], which means:
  *
  * -   Two Iterables are compared element by element.
  * -   Two empty Iterables are lexicographically equal.
@@ -148,9 +148,10 @@
  * }
  * ```
  *
- * [1]: https://mathworld.wolfram.com/EquivalenceRelation.html
- * [2]: https://mathworld.wolfram.com/TotalOrder.html
- * [3]: https://mathworld.wolfram.com/LexicographicOrder.html
+ * [equivalence relations]:
+ *     https://mathworld.wolfram.com/EquivalenceRelation.html
+ * [total orders]: https://mathworld.wolfram.com/TotalOrder.html
+ * [lexicographically]: https://mathworld.wolfram.com/LexicographicOrder.html
  *
  * @module
  */
@@ -158,7 +159,7 @@
 import { cmb, Semigroup } from "./cmb.js";
 
 /**
- * An interface that provides evidence of an [equivalence relation][1].
+ * An interface that provides evidence of an [equivalence relation].
  *
  * ## Properties
  *
@@ -178,7 +179,7 @@ import { cmb, Semigroup } from "./cmb.js";
  * existing prototypes.
  *
  * Implementation is implicit and does not require an `implements` clause.
- * TypeScript uses [structural subtyping][2] to determine whether a value
+ * TypeScript uses [structural subtyping] to determine whether a value
  * implements `Eq`.
  *
  * ### Conditional implementation
@@ -309,9 +310,9 @@ import { cmb, Semigroup } from "./cmb.js";
  *
  * Patching a type in TypeScript requires two steps:
  *
- * 1. an [augmentation][3] for a module or the global scope that patches the
- *    type-level representation; and
- * 1. a concrete implementation for `[Eq.eq]`.
+ * 1.  an [augmentation] for a module or the global scope that patches the
+ *     type-level representation; and
+ * 2.  a concrete implementation for `[Eq.eq]`.
  *
  * The concrete implementation logic is similar to writing a method body for a
  * class or object, and the same practices apply for requiring generic
@@ -352,9 +353,12 @@ import { cmb, Semigroup } from "./cmb.js";
  * };
  * ```
  *
- * [1]: https://mathworld.wolfram.com/EquivalenceRelation.html
- * [2]: https://www.typescriptlang.org/docs/handbook/type-compatibility.html#site-content
- * [3]: https://www.typescriptlang.org/docs/handbook/declaration-merging.html#module-augmentation
+ * [equivalence relation]:
+ *     https://mathworld.wolfram.com/EquivalenceRelation.html
+ * [structural subtyping]:
+ *     https://www.typescriptlang.org/docs/handbook/type-compatibility.html#site-content
+ * [augmentation]:
+ *     https://www.typescriptlang.org/docs/handbook/declaration-merging.html#module-augmentation
  */
 export interface Eq<in A> {
     /**
@@ -437,7 +441,7 @@ export function ieq<A extends Eq<A>>(
 }
 
 /**
- * An interface that provides evidence of a [total order][1].
+ * An interface that provides evidence of a [total order].
  *
  * ## Properties
  *
@@ -460,7 +464,7 @@ export function ieq<A extends Eq<A>>(
  * existing prototypes.
  *
  * Implementation is implicit and does not require an `implements` clause.
- * TypeScript uses [structural subtyping][2] to determine whether a value
+ * TypeScript uses [structural subtyping] to determine whether a value
  * implements `Ord`.
  *
  * ### Conditional implementation
@@ -629,9 +633,9 @@ export function ieq<A extends Eq<A>>(
  *
  * Patching a type in TypeScript requires two steps:
  *
- * 1. an [augmentation][3] for a module or the global scope that patches the
- *    type-level representation; and
- * 1. a concrete implementation for `[Ord.cmp]` and `[Eq.eq]`.
+ * 1.  an [augmentation] for a module or the global scope that patches the
+ *     type-level representation; and
+ * 2.  a concrete implementation for `[Ord.cmp]` and `[Eq.eq]`.
  *
  * The concrete implementation logic is similar to writing a method body for a
  * class or object, and the same practices apply for requiring generic
@@ -685,9 +689,11 @@ export function ieq<A extends Eq<A>>(
  * };
  * ```
  *
- * [1]: https://mathworld.wolfram.com/TotalOrder.html
- * [2]: https://www.typescriptlang.org/docs/handbook/type-compatibility.html#site-content
- * [3]: https://www.typescriptlang.org/docs/handbook/declaration-merging.html#module-augmentation
+ * [total order]: https://mathworld.wolfram.com/TotalOrder.html
+ * [structural subtyping]:
+ *     https://www.typescriptlang.org/docs/handbook/type-compatibility.html#site-content
+ * [augmentation]:
+ *     https://www.typescriptlang.org/docs/handbook/declaration-merging.html#module-augmentation
  */
 export interface Ord<in A> extends Eq<A> {
     /**
@@ -713,7 +719,7 @@ export function cmp<A extends Ord<A>>(x: A, y: A): Ordering {
 }
 
 /**
- * Compare two Iterables of arbitrary values to determing their lexicographical
+ * Compare two Iterables of arbitrary values to determine their lexicographical
  * ordering.
  */
 export function icmpBy<A>(

--- a/src/either.ts
+++ b/src/either.ts
@@ -60,9 +60,8 @@
  * -   `left` constructs a `Left` variant.
  * -   `right` constructs a `Right` variant.
  * -   `guard` constructs an Either from applying a predicate function to a
- *     value.
- *     The value is returned in `Right` or `Left` if it satisfies or does not
- *     satisfy the predicate, respectively.
+ *     value. The value is returned in `Right` or `Left` if it satisfies or does
+ *     not satisfy the predicate, respectively.
  * -   `fromValidated` converts a Validated to an Either. `Disputed` becomes
  *     `Left` and `Accepted` becomes `Right`.
  *
@@ -175,8 +174,7 @@
  * These methods allow an Either to recover from a `Left` variant:
  *
  * -   `recover` applies a function to the Either's value to return a new
- *     Either.
- *     This is the equivalent of `flatMap` for the `Left` variant.
+ *     Either. This is the equivalent of `flatMap` for the `Left` variant.
  * -   `orElse` returns a fallback Either.
  *
  * ## Collecting into `Either`
@@ -382,12 +380,6 @@
  * // inputs ["a","-4"]: "cannot parse 'a' as int"
  * // inputs ["2","-7"]: "-7 is not even"
  * // inputs ["+42","0x2A"]: 84
- * ```
- *
- * ### Web requests with `Either`
- *
- * ```ts
- * // Todo
  * ```
  *
  * @module

--- a/src/eval.ts
+++ b/src/eval.ts
@@ -131,12 +131,17 @@
  * ```ts
  * type Tree<A> = Tip | Bin<A>;
  * type Tip = { typ: "Tip" };
- * type Bin<A> = { typ: "Bin", val: A, ltree: Tree<A>, rtree: Tree<A> };
+ * type Bin<A> = {
+ *     typ: "Bin",
+ *     val: A,       // value
+ *     lst: Tree<A>, // left subtree
+ *     rst: Tree<A>, // right subtree
+ * };
  *
  * const tip: Tree<never> = { typ: "Tip" };
  *
- * function bin<A>(val: A, ltree: Tree<A>, rtree: Tree<A>): Tree<A> {
- *     return { typ: "Bin", val, ltree, rtree };
+ * function bin<A>(val: A, lst: Tree<A>, rst: Tree<A>): Tree<A> {
+ *     return { typ: "Bin", val, lst, rst };
  * }
  *
  * function foldTree<A, B>(
@@ -150,8 +155,8 @@
  *     // Challenge for the reader: why is `defer` needed here?
  *     // Hint: it pertains to stack safety and eager evaluation.
  *     return Eval.defer(() =>
- *         foldTree(xs.ltree, onTip, foldBin).flatMap((l) =>
- *             foldTree(xs.rtree, onTip, foldBin).map((r) =>
+ *         foldTree(xs.lst, onTip, foldBin).flatMap((l) =>
+ *             foldTree(xs.rst, onTip, foldBin).map((r) =>
  *                 foldBin(xs.val, l, r),
  *             ),
  *         ),
@@ -188,8 +193,8 @@
  *         }
  *         // Challenge for the reader: why is `defer` not needed here?
  *         // Hint: it pertains to the behavior of `go`.
- *         const l = yield* foldTree(xs.ltree, onTip, foldBin);
- *         const r = yield* foldTree(xs.rtree, onTip, foldBin);
+ *         const l = yield* foldTree(xs.lst, onTip, foldBin);
+ *         const r = yield* foldTree(xs.rst, onTip, foldBin);
  *         return foldBin(xs.val, l, r);
  *     });
  * }

--- a/src/ior.ts
+++ b/src/ior.ts
@@ -191,7 +191,7 @@
  *
  * Additionally, the `reduce` function reduces a finite Iterable from left to
  * right in the context of `Ior`. This is useful for mapping, filtering, and
- * accumulating values using `Ior`:
+ * accumulating values using `Ior`.
  *
  * ## Examples
  *
@@ -425,12 +425,6 @@
  * //   ["info: parse '2' ok,"err: -7 is not even"]
  * // inputs ["+42" "0x2A"]:
  * //   [["info: parse '+42' ok","info: parse '0x2A' ok"],84]
- * ```
- *
- * ### Web requests with `Ior`
- *
- * ```ts
- * // Todo
  * ```
  *
  * @module

--- a/src/maybe.ts
+++ b/src/maybe.ts
@@ -381,12 +381,6 @@
  * // inputs ["+42","0x2A"]: 84
  * ```
  *
- * ### Web requests with `Maybe`
- *
- * ```ts
- * // Todo
- * ```
- *
  * @module
  */
 
@@ -405,7 +399,7 @@ export type Maybe<A> = Maybe.Nothing | Maybe.Just<A>;
  */
 export namespace Maybe {
     /**
-     * An enumeration that discriminates Maybe.
+     * An enumeration that discriminates `Maybe`.
      */
     export enum Typ {
         Nothing,
@@ -585,8 +579,8 @@ export namespace Maybe {
         }
 
         /**
-         * If this Maybe is `Just`, extract its value; otherwise, return a
-         * fallback value.
+         * If this Maybe is `Just`, extract its value; otherwise, evaluate a
+         * a function to return a fallback value.
          */
         justOrFold<A, B>(this: Maybe<A>, f: () => B): A | B {
             return this.fold(f, id);

--- a/src/validated.ts
+++ b/src/validated.ts
@@ -59,11 +59,10 @@
  *
  * ## Constructing `Validated`
  *
- * The `dispute` and `accept` functions construct the `Disputed` and `Accepted`
- * variants of `Validated`, respectively.
+ * These methods construct a Validated:
  *
- * Furthermore:
- *
+ * -   `dispute` constructs a `Disputed` variant.
+ * -   `accept` constructs an `Accepted` variant.
  * -   `fromEither` constructs a Validated from an Either. `Left` becomes
  *     `Disputed` and `Right` becomes `Accepted`.
  *


### PR DESCRIPTION
- Revise Markdown link references to be more descriptive
- Remove unnecessary newlines
- Revise the property names in examples for `Eval`
- Fix punctuation in docs for `Ior`
- Revise code fences and docs for `justOrFold` method for `Maybe`
- Revise docs for constructing `Validated`
- Remove unfinished doc sections for "Web requests"