### PR TITLE
Revise documentation for grammar and wording

### DIFF
--- a/src/cmp.ts
+++ b/src/cmp.ts
@@ -257,8 +257,8 @@ import { cmb, Semigroup } from "./cmb.js";
  *
  * #### Example: generic type with an `Eq` requirement
  *
- * Consider a type that determines equality by comparing the elements of Arrays
- * by index:
+ * Consider a type that determines equality by comparing the elements of Arrays,
+ * which requires that the elements implement `Eq`:
  *
  * ```ts
  * class Arr<A> {
@@ -568,8 +568,8 @@ export function ieq<A extends Eq<A>>(
  *
  * #### Example: generic type with an `Ord` requirement
  *
- * Consider a type that determines ordering by comparing Arrays
- * lexicographically, which requires that the Array's elements implement `Ord`:
+ * Consider a type that determines ordering by comparing the elements of Arrays
+ * lexicographically, which requires that the elements implement `Ord`:
  *
  * ```ts
  * class Arr<A> {
@@ -590,7 +590,7 @@ export function ieq<A extends Eq<A>>(
  * implementation by writing `A extends Ord<A>` (the name `A` is arbitrary).
  *
  * Then, we require that `this` and `that` are `Arr<A>` where
- * `A extends Ord<A>`. This allows us to use `cmp` to implement our desired
+ * `A extends Ord<A>`. This allows us to use `icmp` to implement our desired
  * behavior.
  *
  * #### Example: generic type with multiple `Ord` requirements

--- a/src/either.ts
+++ b/src/either.ts
@@ -147,8 +147,7 @@
  *
  * -   Variable declarations, assignments, and mutations
  * -   Function and class declarations
- * -   `for` loops
- * -   `while` and `do...while` loops
+ * -   `for`, `while`, and `do`/`while` loops
  * -   `if`/`else if`/`else` blocks
  * -   `switch` blocks
  * -   `try`/`catch` blocks
@@ -156,8 +155,8 @@
  * ### Async generator comprehensions
  *
  * Async generator comprehensions provide `async`/`await` syntax and Promises to
- * `Either` generator comprehensions. Async computations that return `Either`
- * can be chained together using the familiar generator syntax.
+ * `Either` generator comprehensions. Async computations that fulfill with
+ * `Either` can be chained together using the familiar generator syntax.
  *
  * The `goAsync` function evaluates an AsyncGenerator to return a Promise that
  * fulfills with an Either. The semantics of `yield*` and `return` within async

--- a/src/eval.ts
+++ b/src/eval.ts
@@ -90,8 +90,7 @@
  *
  * -   Variable declarations, assignments, and mutations
  * -   Function and class declarations
- * -   `for` loops
- * -   `while` and `do...while` loops
+ * -   `for`, `while`, and `do`/`while` loops
  * -   `if`/`else if`/`else` blocks
  * -   `switch` blocks
  * -   `try`/`catch` blocks

--- a/src/ior.ts
+++ b/src/ior.ts
@@ -24,7 +24,7 @@
  * `Ior` is often used to represent states of failure or success similar to
  * `Either` and `Validated`. However, `Ior` is capable of also representing a
  * unique state using the `Both` variant. `Both` can represent a success that
- * carries additional information, or a state of *partial failure*.
+ * carries additional information, or a state of "partial failure".
  *
  * When composed, the behavior of `Ior` is a combination of the short-circuiting
  * behavior of `Either` and the failure-accumulating behavior of `Validated`:
@@ -36,8 +36,7 @@
  *     combines its left-hand value with any existing left-hand value.
  *
  * Combinators with this behavior will require a `Semigroup` implementation for
- * the accumulating left-hand value. This documentation will use the following
- * semigroup and utility functions in all examples:
+ * the accumulating left-hand value.
  *
  * ## Importing from this module
  *
@@ -102,7 +101,8 @@
  *     (are) equal.
  * -   When compared, `Left` is less than `Right`, and `Right` is less than
  *     `Both`. If the variants are equal, their values determine the ordering.
- *     `Both` compares its `fst` and `snd` properties lexicographically.
+ *     The `Both` variant compares its `fst` and `snd` properties
+ *     lexicographically.
  *
  * ## `Ior` as a semigroup
  *
@@ -153,8 +153,7 @@
  *
  * -   Variable declarations, assignments, and mutations
  * -   Function and class declarations
- * -   `for` loops
- * -   `while` and `do...while` loops
+ * -   `for`, `while`, and `do`/`while` loops
  * -   `if`/`else if`/`else` blocks
  * -   `switch` blocks
  * -   `try`/`catch` blocks
@@ -162,8 +161,8 @@
  * ## Async generator comprehensions
  *
  * Async generator comprehensions provide `async`/`await` syntax and Promises to
- * `Ior` generator comprehensions. Async computations that return `Ior` can be
- * chained together using the familiar generator syntax.
+ * `Ior` generator comprehensions. Async computations that fulfill with `Ior`
+ * can be chained together using the familiar generator syntax.
  *
  * The `goAsync` function evaluates an AsyncGenerator to return a Promise that
  * fulfills with an Ior. The semantics of `yield*` and `return` within async
@@ -183,8 +182,8 @@
  *
  * These methods will traverse a collection of Iors to extract the right-hand
  * values. If any Ior in the collection is `Left`, the traversal is halted and
- * and the `Left` is returned instead. An implementation for `Semigroup` is
- * required for left-hand values so they may accumulate.
+ * the `Left` is returned instead. An implementation for `Semigroup` is required
+ * for left-hand values so they may accumulate.
  *
  * -   `collect` turns an Array or a tuple literal of Iors inside out.
  * -   `gather` turns a Record or an object literal of Iors inside out.

--- a/src/maybe.ts
+++ b/src/maybe.ts
@@ -144,8 +144,7 @@
  *
  * -   Variable declarations, assignments, and mutations
  * -   Function and class declarations
- * -   `for` loops
- * -   `while` and `do...while` loops
+ * -   `for`, `while`, and `do`/`while` loops
  * -   `if`/`else if`/`else` blocks
  * -   `switch` blocks
  * -   `try`/`catch` blocks
@@ -153,8 +152,8 @@
  * ### Async generator comprehensions
  *
  * Async generator comprehensions provide `async`/`await` syntax and Promises to
- * `Maybe` generator comprehensions. Async computations that return `Maybe` can
- * be chained together using the familiar generator syntax.
+ * `Maybe` generator comprehensions. Async computations that fulfill with
+ * `Maybe` can be chained together using the familiar generator syntax.
  *
  * The `goAsync` function evaluates an AsyncGenerator to return a Promise that
  * fulfills with a Maybe. The semantics of `yield*` and `return` within async
@@ -580,7 +579,7 @@ export namespace Maybe {
 
         /**
          * If this Maybe is `Just`, extract its value; otherwise, evaluate a
-         * a function to return a fallback value.
+         * function to return a fallback value.
          */
         justOrFold<A, B>(this: Maybe<A>, f: () => B): A | B {
             return this.fold(f, id);

--- a/src/pair.ts
+++ b/src/pair.ts
@@ -54,14 +54,14 @@
  * `Pair` implements `Eq` and `Ord` when both its first and second generic types
  * implement `Eq` and `Ord`, respectively.
  *
- * -   Two pairs are equal if their first and second values are respectively
+ * -   Two Pairs are equal if their first and second values are respectively
  *     equal.
- * -   `Pair` compares its first and second values lexicographically.
+ * -   Pairs compare their first and second values lexicographically.
  *
  * ## `Pair` as a semigroup
  *
  * `Pair` implements `Semigroup` when both its first and second generic types
- * implement `Semigroup`. First and second values are combined pairwise.
+ * implement `Semigroup`. The first and second values are combined pairwise.
  *
  * ## Transforming values
  *

--- a/src/validated.ts
+++ b/src/validated.ts
@@ -28,8 +28,7 @@
  *
  * Most combinators for `Validated` will begin accumulating `Disputed` values on
  * the first encountered `Disputed` variant. Combinators with this behavior will
- * will require a `Semigroup` implementation for the accumulating `Disputed`
- * value. This documentation will use the following semigroup in all examples:
+ * require a `Semigroup` implementation for the accumulating `Disputed` value.
  *
  * ## Importing from this module
  *


### PR DESCRIPTION
- Remove duplicate words
- Remove some stale sentences
- Consolidate and reword docs for generator comprehensions
- Reword some docs for comparing and combining types