### PR TITLE
Update TypeDoc dependency and adjust docs build process

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -23,7 +23,7 @@
                 "prettier-plugin-organize-imports": "^3.1.1",
                 "rimraf": "^3.0.2",
                 "ts-node": "^10.9.1",
-                "typedoc": "0.23.14",
+                "typedoc": "0.23.19",
                 "typescript": "~4.8"
             },
             "engines": {
@@ -3029,9 +3029,9 @@
             }
         },
         "node_modules/typedoc": {
-            "version": "0.23.14",
-            "resolved": "https://registry.npmjs.org/typedoc/-/typedoc-0.23.14.tgz",
-            "integrity": "sha512-s2I+ZKBET38EctZvbXp2GooHrNaKjWZkrwGEK/sttnOGiKJqU0vHrsdcwLgKZGuo2aedNL3RRPj1LnAAeYscig==",
+            "version": "0.23.19",
+            "resolved": "https://registry.npmjs.org/typedoc/-/typedoc-0.23.19.tgz",
+            "integrity": "sha512-70jPL0GQnSJtgQqI7ifOWxpTXrB3sxc4SWPPRn3K0wdx3txI6ZIT/ZYMF39dNg2Gjmql45cO+cAKXJp0TpqOVA==",
             "dev": true,
             "dependencies": {
                 "lunr": "^2.3.9",
@@ -5403,9 +5403,9 @@
             "dev": true
         },
         "typedoc": {
-            "version": "0.23.14",
-            "resolved": "https://registry.npmjs.org/typedoc/-/typedoc-0.23.14.tgz",
-            "integrity": "sha512-s2I+ZKBET38EctZvbXp2GooHrNaKjWZkrwGEK/sttnOGiKJqU0vHrsdcwLgKZGuo2aedNL3RRPj1LnAAeYscig==",
+            "version": "0.23.19",
+            "resolved": "https://registry.npmjs.org/typedoc/-/typedoc-0.23.19.tgz",
+            "integrity": "sha512-70jPL0GQnSJtgQqI7ifOWxpTXrB3sxc4SWPPRn3K0wdx3txI6ZIT/ZYMF39dNg2Gjmql45cO+cAKXJp0TpqOVA==",
             "dev": true,
             "requires": {
                 "lunr": "^2.3.9",

--- a/package.json
+++ b/package.json
@@ -74,7 +74,7 @@
         "prettier-plugin-organize-imports": "^3.1.1",
         "rimraf": "^3.0.2",
         "ts-node": "^10.9.1",
-        "typedoc": "0.23.14",
+        "typedoc": "0.23.19",
         "typescript": "~4.8"
     },
     "eslintConfig": {

--- a/scripts/gen_docsite.tsx
+++ b/scripts/gen_docsite.tsx
@@ -96,8 +96,11 @@ const refl = app.convert();
 
 if (refl) {
     const out = app.options.getValue("out");
+    const jsonOut = app.options.getValue("json");
+
     app.validate(refl);
     await app.generateDocs(refl, out);
+    await app.generateJson(refl, jsonOut);
 } else {
     throw new Error("could not generate reflections");
 }

--- a/tsconfig.json
+++ b/tsconfig.json
@@ -26,8 +26,8 @@
     "include": ["./scripts", "./src", "./test"],
     "typedocOptions": {
         "entryPoints": "./src/*.ts",
-        "entryPointStrategy": "expand",
         "excludePrivate": true,
+        "json": "./docsite/docs.json",
         "name": "Neotype Prelude",
         "out": "./docsite",
         "theme": "custom"


### PR DESCRIPTION
- Upgrade TypeDoc to its latest version
- Generate JSON and output to `site_url/docs.json`
- Remove the `entryPointStrategy` config setting. This didn't seem to be making any difference with how `entryPoints` are configured.