### PR TITLE
Add TSDoc tags to the documentation

### DIFF
--- a/scripts/gen_docsite.tsx
+++ b/scripts/gen_docsite.tsx
@@ -11,6 +11,8 @@ import {
 } from "typedoc";
 
 const customCss = `
+@import url('https://fonts.googleapis.com/css2?family=Open+Sans:ital,wght@0,300;0,400;0,600;0,700;0,800;1,300;1,400;1,600;1,700;1,800&family=Source+Code+Pro:wght@400&display=swap');
+
 body {
     font-family: "Open Sans", sans-serif;
 }
@@ -46,6 +48,15 @@ code {
 pre {
     padding: 1rem;
 }
+
+.tsd-signature {
+    font-size: unset;
+    font-family: "Source Code Pro", monospace;
+}
+
+.tsd-signature-type {
+    font-style: unset;
+}
 `;
 
 class CustomTheme extends DefaultTheme {
@@ -64,22 +75,7 @@ class CustomTheme extends DefaultTheme {
 
 export function load(app: Application) {
     app.renderer.hooks.on("head.end", (ctx) => (
-        <>
-            <link rel="preconnect" href="https://fonts.googleapis.com" />
-            <link
-                rel="preconnect"
-                href="https://fonts.gstatic.com"
-                crossOrigin={undefined}
-            />
-            <link
-                href="https://fonts.googleapis.com/css2?family=Open+Sans&family=Source+Code+Pro&family=Source+Serif+Pro&display=swap"
-                rel="stylesheet"
-            />
-            <link
-                rel="stylesheet"
-                href={ctx.relativeURL("assets/custom.css")}
-            />
-        </>
+        <link rel="stylesheet" href={ctx.relativeURL("assets/custom.css")} />
     ));
 
     app.renderer.defineTheme("custom", CustomTheme);

--- a/src/cmb.ts
+++ b/src/cmb.ts
@@ -17,6 +17,8 @@
 /**
  * Functionality for associative combination.
  *
+ * @remarks
+ *
  * ## Importing from this module
  *
  * This module exposes utilities for working with semigroups. It is recommended
@@ -37,15 +39,19 @@
  *
  * The `cmb` function combines two instances of the same `Semigroup`.
  *
- * ## Working with semigroups
+ * ## Working with generic semigroups
  *
  * Often, code must be written to accept arbitrary semigroups. To require that
  * a generic type `A` implements `Semigroup`, we write `A extends Semigroup<A>`.
  *
- * Consider a function that combines an arbitrary semigroup with itself a finite
+ * @example Working with generic semigroups
+ *
+ * Consider a program that combines an arbitrary semigroup with itself a finite
  * number of times:
  *
  * ```ts
+ * import { cmb, Semigroup } from "@neotype/prelude/cmp.js";
+ *
  * function cmbTimes<A extends Semigroup<A>>(x: A, n: number): A {
  *     if (n < 2 || n === Infinity) {
  *         return x;
@@ -66,6 +72,8 @@
 
 /**
  * An interface that provides evidence of a [semigroup].
+ *
+ * @remarks
  *
  * ## Properties
  *
@@ -113,11 +121,33 @@
  * -   do not provide access to their implementation, and where patching the
  *     implementation is undesireable.
  *
- * #### Example: non-generic type
+ * ### Patching existing prototypes
+ *
+ * Existing types can be patched to implement `Semigroup`. This strategy works
+ * well for types that:
+ *
+ * -   are built-in or imported from external modules.
+ * -   do not provide access to their implementation.
+ * -   have a single, specific behavior as a semigroup, or where the programmer
+ *     wishes to implement a default behavior.
+ *
+ * Patching a type in TypeScript requires two steps:
+ *
+ * 1.  an [augmentation] for a module or the global scope that patches the
+ *     type-level representation; and
+ * 2.  a concrete implementation for `[Semigroup.cmb]`.
+ *
+ * The concrete implementation logic is similar to writing a method body for a
+ * class or object, and the same practices apply when requiring generic type
+ * parameters to implement `Semigroup`.
+ *
+ * @example Non-generic implementation
  *
  * Consider a type that combines strings using concatenation:
  *
  * ```ts
+ * import { Semigroup } from "@neotype/prelude/cmb.js";
+ *
  * class Str {
  *     constructor(readonly val: string) {}
  *
@@ -127,11 +157,13 @@
  * }
  * ```
  *
- * #### Example: generic type with no `Semigroup` requirements
+ * @example Generic implementation with no `Semigroup` requirements
  *
  * Consider a type that combines Arrays using concatenation:
  *
  * ```ts
+ * import { Semigroup } from "@neotype/prelude/cmb.js";
+ *
  * class Concat<A> {
  *     constructor(readonly val: A[]) {}
  *
@@ -144,12 +176,14 @@
  * Notice how `Concat` is generic, but there are no special requirements for
  * implementing `[Semigroup.cmb]`.
  *
- * #### Example: generic type with a `Semigroup` requirement
+ * @example Generic implementation with a `Semigroup` requirement
  *
  * Consider a type that combines Promises by combining their values, which
  * requires that their values also implement `Semigroup`:
  *
  * ```ts
+ * import { cmb, Semigroup } from "@neotype/prelude/cmb.js";
+ *
  * class Async<A> {
  *     constructor(readonly val: Promise<A>) {}
  *
@@ -173,12 +207,14 @@
  * `A extends Semigroup<A>`. This allows us to use `cmb` to implement our
  * desired behavior.
  *
- * #### Example: generic type with multiple `Semigroup` requirements
+ * @example Generic implementation with multiple `Semigroup` requirements
  *
  * Consider a type that combines two values pairwise, which requires that each
  * value implement `Semigroup`:
  *
  * ```ts
+ * import { cmb, Semigroup } from "@neotype/prelude/cmb.js";
+ *
  * class Pair<A, B> {
  *     constructor(readonly fst: A, readonly snd: B) {}
  *
@@ -195,31 +231,13 @@
  * now two method-scoped type parameters that are each required to implement
  * `Semigroup`.
  *
- * ### Patching existing prototypes
- *
- * Existing types can be patched to implement `Semigroup`. This strategy works
- * well for types that:
- *
- * -   are built-in or imported from external modules.
- * -   do not provide access to their implementation.
- * -   have a single, specific behavior as a semigroup, or where the programmer
- *     wishes to implement a default behavior.
- *
- * Patching a type in TypeScript requires two steps:
- *
- * 1.  an [augmentation] for a module or the global scope that patches the
- *     type-level representation; and
- * 2.  a concrete implementation for `[Semigroup.cmb]`.
- *
- * The concrete implementation logic is similar to writing a method body for a
- * class or object, and the same practices apply when requiring generic type
- * parameters to implement `Semigroup`.
- *
- * #### Examples
+ * @example Non-generic augmentation
  *
  * Consider a global augmentation for the `String` prototype:
  *
  * ```ts
+ * import { Semigroup } from "@neotype/prelude/cmb.js";
+ *
  * declare global {
  *     interface String {
  *         [Semigroup.cmb](that: string): string
@@ -231,9 +249,12 @@
  * };
  * ```
  *
+ * @example Generic augmentation
+ *
  * Consider a module augmentation for an externally defined `Pair` type:
  *
  * ```ts
+ * import { cmb, Semigroup } from "@neotype/prelude/cmb.js";
  * import { Pair } from "path_to/pair.js";
  *
  * declare module "path_to/pair.js" {
@@ -277,6 +298,8 @@ export namespace Semigroup {
 
 /**
  * Combine two values of the same semigroup.
+ *
+ * @remarks
  *
  * `cmb(x, y)` is equivalent to `x[Semigroup.cmb](y)`.
  */

--- a/src/either.ts
+++ b/src/either.ts
@@ -17,6 +17,8 @@
 /**
  * Functional unions and railway-oriented programming.
  *
+ * @remarks
+ *
  * `Either<A, B>` is a type that represents one of two values `A` and `B`; thus,
  * `Either` is represented by two variants: `Left<A>` and `Right<B>`.
  *
@@ -193,17 +195,11 @@
  * right in the context of `Either`. This is useful for mapping, filtering, and
  * accumulating values using `Either`.
  *
- * ## Examples
- *
- * These examples assume the following imports:
+ * @example Basic matching and folding
  *
  * ```ts
  * import { Either } from "@neotype/prelude/either.js";
- * ```
  *
- * ### Basic matching and folding
- *
- * ```ts
  * const strOrNum: Either<string, number> = Either.right(1);
  *
  * // Querying and narrowing using methods
@@ -229,9 +225,15 @@
  * );
  * ```
  *
- * ### Parsing with `Either`
+ * @example Parsing with `Either`
  *
- * Consider a program that uses `Either` to parse an even integer:
+ * First, our imports:
+ *
+ * ```ts
+ * import { Either } from "@neotype/prelude/either.js";
+ * ```
+ *
+ * Now, consider a program that uses `Either` to parse an even integer:
  *
  * ```ts
  * function parseInt(input: string): Either<string, number> {

--- a/src/eval.ts
+++ b/src/eval.ts
@@ -17,6 +17,8 @@
 /**
  * Control over synchronous execution.
  *
+ * @remarks
+ *
  * `Eval<A>` is a type that controls the execution of a synchronous computation
  * that returns a result `A`. `Eval` can suspend and memoize evaluation for a
  * variety of use cases, and it provides stack-safe execution for recursive
@@ -114,17 +116,15 @@
  * right in the context of `Eval`. This is useful for mapping, filtering, and
  * accumulating values using `Eval`.
  *
- * ## Examples
+ * @example Recursive folds with `Eval`
  *
- * These examples assume the following imports:
+ * First, our imports:
  *
  * ```ts
  * import { Eval } from "@neotype/prelude/eval.js";
  * ```
  *
- * ### Recursive folds with `Eval`
- *
- * Consider a program that uses `Eval` to fold over and traverse a recursive
+ * Now, consider a program that uses `Eval` to traverse and fold a recursive
  * `Tree` data structure:
  *
  * ```ts

--- a/src/fn.ts
+++ b/src/fn.ts
@@ -30,6 +30,8 @@ export function id<A>(x: A): A {
 /**
  * Return a function that always returns a provided value.
  *
+ * @remarks
+ *
  * This function is useful for eagerly memoizing a value that would otherwise be
  * suspended behind a function.
  */

--- a/src/ior.ts
+++ b/src/ior.ts
@@ -17,6 +17,8 @@
 /**
  * Functionality for "inclusive-or" relationships.
  *
+ * @remarks
+ *
  * `Ior<A, B>` is a type that represents *one or both* of two values `A` and
  * `B`; thus, `Ior` is represented by three variants: `Left<A>`, `Right<B>`,
  * and `Both<A, B>`.
@@ -192,47 +194,11 @@
  * right in the context of `Ior`. This is useful for mapping, filtering, and
  * accumulating values using `Ior`.
  *
- * ## Examples
- *
- * These examples assume the following imports and utilities:
+ * @example Basic matching and folding
  *
  * ```ts
- * import { Semigroup } from "@neotype/prelude/cmb.js";
- * import { Ior } from "@neotype/prelude/ior.js";
+ * import { Ior } from "@neotype/prelude/ior.js"
  *
- * // A semigroup that wraps Arrays.
- * class List<A> {
- *     readonly val: A[];
- *
- *     constructor(...vals: A[]) {
- *         this.val = vals;
- *     }
- *
- *     [Semigroup.cmb](that: List<A>): List<A> {
- *         return new List(...this.val, ...that.val);
- *     }
- *
- *     toJSON(): A[] {
- *         return this.val;
- *     }
- * }
- *
- * // A `Log` represents a List of entries relevant to our program. Log entries
- * // have a log level of "info" or "err".
- * type Log = List<string>;
- *
- * function info(msg: string): Log {
- *     return new List(`info: ${msg}`);
- * }
- *
- * function err(msg: string): Log {
- *     return new List(`err: ${msg}`);
- * }
- * ```
- *
- * ### Basic matching and folding
- *
- * ```ts
  * const strIorNum: Ior<string, number> = Ior.both("a", 1);
  *
  * // Querying and narrowing using methods
@@ -264,9 +230,50 @@
  * );
  * ```
  *
- * ### Parsing with `Ior`
+ * @example Parsing with `Ior`
  *
- * Consider a program that uses `Ior` to parse an even integer:
+ * First, our imports:
+ *
+ * ```ts
+ * import { Semigroup } from "@neotype/prelude/cmb.js";
+ * import { Ior } from "@neotype/prelude/ior.js";
+ * ```
+ *
+ * For our example, let's also define a helper semigroup type and some other
+ * utilities:
+ *
+ * ```ts
+ * // A semigroup that wraps Arrays.
+ * class List<A> {
+ *     readonly val: A[];
+ *
+ *     constructor(...vals: A[]) {
+ *         this.val = vals;
+ *     }
+ *
+ *     [Semigroup.cmb](that: List<A>): List<A> {
+ *         return new List(...this.val, ...that.val);
+ *     }
+ *
+ *     toJSON(): A[] {
+ *         return this.val;
+ *     }
+ * }
+ *
+ * // A `Log` represents a List of entries relevant to our program. Log entries
+ * // have a log level of "info" or "err".
+ * type Log = List<string>;
+ *
+ * function info(msg: string): Log {
+ *     return new List(`info: ${msg}`);
+ * }
+ *
+ * function err(msg: string): Log {
+ *     return new List(`err: ${msg}`);
+ * }
+ * ```
+ *
+ * Now, consider a program that uses `Ior` to parse an even integer.
  *
  * ```ts
  * function parseInt(input: string): Ior<Log, number> {
@@ -478,6 +485,8 @@ export namespace Ior {
 
     /**
      * Construct an Ior from an Either.
+     *
+     * @remarks
      *
      * `Right` and `Left` Eithers will become `Right` and `Left` Iors,
      * respectively.

--- a/src/maybe.ts
+++ b/src/maybe.ts
@@ -17,6 +17,8 @@
 /**
  * Optional values.
  *
+ * @remarks
+ *
  * `Maybe<A>` is a type that represents an optional value `A`, and is
  * represented by two variants: `Nothing` describes an absent value, and
  * `Just<A>` describes a present value.
@@ -186,17 +188,11 @@
  * right in the context of `Maybe`. This is useful for mapping, filtering, and
  * accumulating values using `Maybe`.
  *
- * ## Examples
- *
- * These examples assume the following imports:
+ * @example Basic matching and folding
  *
  * ```ts
- * import { Maybe } from "@neotype/prelude/maybe.js";
- * ```
+ * import { Maybe } from "@neotype/prelude/maybe.js"
  *
- * ### Basic matching and folding
- *
- * ```ts
  * const maybeNum: Maybe<number> = Maybe.just(1);
  *
  * // Querying and narrowing using methods
@@ -222,9 +218,15 @@
  * );
  * ```
  *
- * ### Parsing with `Maybe`
+ * @example Parsing with `Maybe`
  *
- * Consider a program that uses `Maybe` to parse an even integer:
+ * First, our imports:
+ *
+ * ```ts
+ * import { Maybe } from "@neotype/prelude/maybe.js";
+ * ```
+ *
+ * Now, consider a program that uses `Maybe` to parse an even integer:
  *
  * ```ts
  * function parseInt(input: string): Maybe<number> {

--- a/src/pair.ts
+++ b/src/pair.ts
@@ -17,6 +17,8 @@
 /**
  * Pairs of values.
  *
+ * @remarks
+ *
  * `Pair<A, B>` is a type that represents a pair of values `A` and `B`. Pairs
  * provide equivalence relations, total orders, and semigroups for two or more
  * values.

--- a/src/validated.ts
+++ b/src/validated.ts
@@ -49,7 +49,7 @@
  * import { Validated } from "@neotype/prelude/validated.js";
  * ```
  *
- * Or, the type ane namespace can be imported and aliased separately:
+ * Or, the type and namespace can be imported and aliased separately:
  *
  * ```ts
  * import {
@@ -434,7 +434,7 @@ export namespace Validated {
         let acc = accept<any, any>({});
         for (const [key, vtd] of Object.entries(vtds)) {
             acc = acc.zipWith(vtd, (results, x) => {
-                results[key as keyof T] = x;
+                results[key] = x;
                 return results;
             });
         }

--- a/src/validated.ts
+++ b/src/validated.ts
@@ -17,6 +17,8 @@
 /**
  * Validation with accumulating failures.
  *
+ * @remarks
+ *
  * `Validated<E, A>` is a type that represents a state of accumulated failure or
  * success; thus, `Validated` is represented by two variants: `Disputed<E>` and
  * `Accepted<A>`.
@@ -140,14 +142,18 @@
  * -   `collect` turns an Array or a tuple literal of Validateds inside out.
  * -   `gather` turns a Record or an object literal of Validateds inside out.
  *
- * ## Examples
+ * @example Validating a single property
  *
- * These examples assume the following imports and utilities:
+ * First, our imports:
  *
  * ```ts
  * import { Semigroup } from "@neotype/prelude/cmb.js";
  * import { Validated } from "@neotype/prelude/validated.js";
+ * ```
  *
+ * Let's also define a helper semigroup type:
+ *
+ * ```ts
  * // A semigroup that wraps Arrays
  * class List<A> {
  *     readonly val: A[]
@@ -166,7 +172,7 @@
  * }
  * ```
  *
- * ### Validating a single property
+ * Now, consider a program that performs a trivial email validation:
  *
  * ```ts
  * function requireNonEmpty(input: string): Validated<List<string>, string> {
@@ -207,7 +213,38 @@
  * // input "neo@gmail.com": "neo@gmail.com"
  * ```
  *
- * ### Validating multiple properties
+ * @example Validating multiple properties
+ *
+ * First, our imports:
+ *
+ * ```ts
+ * import { Semigroup } from "@neotype/prelude/cmb.js";
+ * import { Validated } from "@neotype/prelude/validated.js";
+ * ```
+ *
+ * Let's also define a helper semigroup type:
+ *
+ * ```ts
+ * // A semigroup that wraps Arrays
+ * class List<A> {
+ *     readonly val: A[]
+ *
+ *     constructor(...vals: A[]) {
+ *         this.val = vals;
+ *     }
+ *
+ *     [Semigroup.cmb](that: List<A>): List<A> {
+ *         return new List(...this.val, ...that.val);
+ *     }
+ *
+ *     toJSON(): A[] {
+ *         return this.val;
+ *     }
+ * }
+ * ```
+ *
+ * Now, consider a program that validates a `Person` object with a `name` and an
+ * `age`:
  *
  * ```ts
  * interface Person {
@@ -254,7 +291,37 @@
  * // inputs ["Neo",45]: {"name":"Neo","age":45}
  * ```
  *
- * ### Validating arbitrary properties
+ * @example Validating arbitrary properties
+ *
+ * First, our imports:
+ *
+ * ```ts
+ * import { Semigroup } from "@neotype/prelude/cmb.js";
+ * import { Validated } from "@neotype/prelude/validated.js";
+ * ```
+ *
+ * Let's also define a helper semigroup type:
+ *
+ * ```ts
+ * // A semigroup that wraps Arrays
+ * class List<A> {
+ *     readonly val: A[]
+ *
+ *     constructor(...vals: A[]) {
+ *         this.val = vals;
+ *     }
+ *
+ *     [Semigroup.cmb](that: List<A>): List<A> {
+ *         return new List(...this.val, ...that.val);
+ *     }
+ *
+ *     toJSON(): A[] {
+ *         return this.val;
+ *     }
+ * }
+ * ```
+ *
+ * Now, consider a program that validates an arbitrary-length Array of strings:
  *
  * ```ts
  * function requireLowercase(input: string): Validated<List<string>, string> {
@@ -284,7 +351,7 @@
  * });
  *
  * // inputs ["New York","Oregon"]: {"invalid":["New York","Oregon"]}
- * // inputs ["foo","Bar","baz"]: {"invalid":["Bar"]}
+ * // inputs ["Code","of","Conduct"]: {"invalid":["Code","Conduct"]}
  * // inputs ["banana","apple","orange"]: {"valid":["banana","apple","orange"]}
  * ```
  *
@@ -329,7 +396,7 @@ export namespace Validated {
     }
 
     /**
-     * Convert an Either to a Validated.
+     * Construct a Validated from an Either.
      */
     export function fromEither<E, A>(either: Either<E, A>): Validated<E, A> {
         return either.fold(dispute, accept);


### PR DESCRIPTION
- Add `@remarks` tags to distinguish "summary" sections from "remarks" sections
- Move examples from plain Markdown headings to `@example` tags
- Ensure all examples are isolated and include all relevant imports and types