### PR TITLE
Remove the `*OrFold` methods

### DIFF
--- a/src/either.ts
+++ b/src/either.ts
@@ -80,15 +80,8 @@
  *
  * An Either's value can be accessed via the `val` property. The type of the
  * property can be narrowed by first querying the Either's variant.
- *
- * These methods also extract an Either's value:
- *
- * -   `fold` applies one of two functions to the value, depending on the
- *     Either's variant.
- * -   `leftOrFold` extracts the value if the Either is `Left`; otherwise, it
- *     applies a function to the `Right` value to return a fallback result.
- * -   `rightOrFold` extracts the value if the Either is `Right`; otherwise, it
- *     applies a function to the `Left` value to return a fallback result.
+ * Additionally, the `fold` method unwraps an `Either` by applying one of two
+ * functions to the value, depending on Either's variant.
  *
  * ## Comparing `Either`
  *
@@ -589,22 +582,6 @@ export namespace Either {
             foldR: (x: B) => D,
         ): C | D {
             return this.isLeft() ? foldL(this.val) : foldR(this.val);
-        }
-
-        /**
-         * If this Either is `Left`, extract its value; otherwise, apply a
-         * function to the `Right` value.
-         */
-        leftOrFold<A, B, C>(this: Either<A, B>, f: (x: B) => C): A | C {
-            return this.fold(id, f);
-        }
-
-        /**
-         * If this Either is `Right`, extract its value; otherwise, apply a
-         * function to the `Left` value.
-         */
-        rightOrFold<A, B, C>(this: Either<A, B>, f: (x: A) => C): B | C {
-            return this.fold(f, id);
         }
 
         /**

--- a/src/maybe.ts
+++ b/src/maybe.ts
@@ -90,12 +90,8 @@
  * function in the case of `Nothing`, or applying a function to the `Just`
  * value.
  *
- * These methods will extract the value from a `Just` Maybe. If the Maybe is
- * `Nothing`:
- *
- * -   `justOrFold` returns the result of evaluating a provided fallback
- *     function.
- * -   `justOr` returns a provided fallback value.
+ * The `justOr` method also unwraps a Maybe by extracting the value in the case
+ * of `Just`, or returning a provided fallback value in the case of `Nothing`.
  *
  * ## Comparing `Maybe`
  *
@@ -575,14 +571,6 @@ export namespace Maybe {
             foldJ: (x: A) => C,
         ): B | C {
             return this.isNothing() ? foldN() : foldJ(this.val);
-        }
-
-        /**
-         * If this Maybe is `Just`, extract its value; otherwise, evaluate a
-         * function to return a fallback value.
-         */
-        justOrFold<A, B>(this: Maybe<A>, f: () => B): A | B {
-            return this.fold(f, id);
         }
 
         /**

--- a/test/either_test.ts
+++ b/test/either_test.ts
@@ -214,22 +214,6 @@ describe("Either", () => {
         assert.deepEqual(t1, [_2, _4]);
     });
 
-    specify("#leftOrFold", () => {
-        const t0 = mk("L", _1, _2).leftOrFold((x) => tuple(x, _4));
-        assert.strictEqual(t0, _1);
-
-        const t1 = mk("R", _1, _2).leftOrFold((x) => tuple(x, _4));
-        assert.deepEqual(t1, [_2, _4]);
-    });
-
-    specify("#rightOrFold", () => {
-        const t0 = mk("L", _1, _2).rightOrFold((x) => tuple(x, _3));
-        assert.deepEqual(t0, [_1, _3]);
-
-        const t1 = mk("R", _1, _2).rightOrFold((x) => tuple(x, _3));
-        assert.strictEqual(t1, _2);
-    });
-
     specify("#bindLeft", () => {
         const t0 = mk("L", _1, _2).recover((x) => mk("L", tuple(x, _3), _4));
         assert.deepEqual(t0, Either.left([_1, _3] as const));

--- a/test/maybe_test.ts
+++ b/test/maybe_test.ts
@@ -211,11 +211,6 @@ describe("Maybe", () => {
         assert.deepEqual(t1, [_1, _2]);
     });
 
-    specify("#justOrFold", () => {
-        const t0 = mk("J", _1).justOrFold(() => _2);
-        assert.strictEqual(t0, _1);
-    });
-
     specify("#justOr", () => {
         const t0 = mk("J", _1).justOr(_2);
         assert.strictEqual(t0, _1);

--- a/test/validation_test.ts
+++ b/test/validation_test.ts
@@ -163,22 +163,6 @@ describe("Validation", () => {
         assert.deepEqual(t1, [_2, _4]);
     });
 
-    specify("#errOrFold", () => {
-        const t0 = mk("Err", _1, _2).errOrFold((x) => tuple(x, _4));
-        assert.strictEqual(t0, _1);
-
-        const t1 = mk("Ok", _1, _2).errOrFold((x) => tuple(x, _4));
-        assert.deepEqual(t1, [_2, _4]);
-    });
-
-    specify("#okOrFold", () => {
-        const t0 = mk("Err", _1, _2).okOrFold((x) => tuple(x, _3));
-        assert.deepEqual(t0, [_1, _3]);
-
-        const t1 = mk("Ok", _1, _2).okOrFold((x) => tuple(x, _3));
-        assert.strictEqual(t1, _2);
-    });
-
     specify("#zipWith", () => {
         const t0 = mk("Err", sa, _2).zipWith(mk("Err", sc, _4), tuple);
         assert.deepEqual(t0, Validation.err(cmb(sa, sc)));


### PR DESCRIPTION
Prefer `fold` with `id`, and direct property access, where needed.