### PR TITLE
Introduce the `lift` combinators and `wrapCtor` function

### DIFF
--- a/src/either.ts
+++ b/src/either.ts
@@ -188,6 +188,15 @@
  * right in the context of `Either`. This is useful for mapping, filtering, and
  * accumulating values using `Either`.
  *
+ * ## Lifting functions to work with `Either`
+ *
+ * The `lift` function receives an ordinary function that accepts arbitrary
+ * agruments, and returns an adapted function that accepts `Either` values as
+ * arguments instead. The arguments are evaluated from left to right, and if
+ * they are all `Right` variants, the original function is applied to their
+ * values and returned in a `Right`. If any `Either` is a `Left`, that `Either`
+ * is returned instead.
+ *
  * @example Basic matching and unwrapping
  *
  * ```ts
@@ -506,6 +515,18 @@ export namespace Either {
             }
             return results as { [K in keyof T]: RightT<T[K]> };
         });
+    }
+
+    /**
+     * Lift a function of any arity into the context of `Either`.
+     */
+    export function lift<T extends readonly unknown[], A>(
+        f: (...args: T) => A,
+    ): <T1 extends { [K in keyof T]: Either<any, T[K]> }>(
+        ...eithers: T1
+    ) => Either<LeftT<T1[number]>, A> {
+        return (...eithers) =>
+            collect(eithers).map((args) => f(...(args as T)));
     }
 
     /**

--- a/src/eval.ts
+++ b/src/eval.ts
@@ -116,6 +116,13 @@
  * right in the context of `Eval`. This is useful for mapping, filtering, and
  * accumulating values using `Eval`.
  *
+ * ## Lifting functions to work with `Eval`
+ *
+ * The `lift` function receives an ordinary function that accepts arbitrary
+ * agruments, and returns an adapted function that accepts `Eval` values as
+ * arguments instead. The arguments are evaluated from left to right, then the
+ * original function is applied to the results.
+ *
  * @example Recursive folds with `Eval`
  *
  * First, our imports:
@@ -377,6 +384,15 @@ export class Eval<out A> {
             }
             return results as { [K in keyof T]: Eval.ResultT<T[K]> };
         });
+    }
+
+    /**
+     * Lift a function of any arity into the context of `Eval`.
+     */
+    static lift<T extends readonly unknown[], A>(
+        f: (...args: T) => A,
+    ): (...evals: { [K in keyof T]: Eval<T[K]> }) => Eval<A> {
+        return (...evals) => Eval.collect(evals).map((args) => f(...args));
     }
 
     /**

--- a/src/fn.ts
+++ b/src/fn.ts
@@ -55,3 +55,12 @@ export function negate<T extends unknown[]>(
 ): (...args: T) => boolean {
     return (...args) => !f(...args);
 }
+
+/**
+ * Adapt a constructor of any arity into a callable function.
+ */
+export function wrapCtor<T extends readonly unknown[], A>(
+    ctor: new (...args: T) => A,
+): (...args: T) => A {
+    return (...args) => new ctor(...args);
+}

--- a/src/ior.ts
+++ b/src/ior.ts
@@ -194,6 +194,14 @@
  * right in the context of `Ior`. This is useful for mapping, filtering, and
  * accumulating values using `Ior`.
  *
+ * ## Lifting functions to work with `Ior`
+ *
+ * The `lift` function receives an ordinary function that accepts arbitrary
+ * agruments, and returns an adapted function that accepts `Ior` values as
+ * arguments instead. The arguments are evaluated from left to right, then the
+ * original function is applied to the right-hand values and returned as a
+ * right-hand value.
+ *
  * @example Basic matching and unwrapping
  *
  * ```ts
@@ -567,6 +575,18 @@ export namespace Ior {
             }
             return results;
         }) as Ior<LeftT<T[keyof T]>, { [K in keyof T]: RightT<T[K]> }>;
+    }
+
+    /**
+     * Lift a function of any arity into the context of `Ior`.
+     */
+    export function lift<T extends readonly unknown[], A>(
+        f: (...args: T) => A,
+    ): <E extends Semigroup<E>>(
+        ...iors: { [K in keyof T]: Ior<E, T[K]> }
+    ) => Ior<E, A> {
+        return (...iors) =>
+            collect(iors).map((args) => f(...(args as T))) as Ior<any, A>;
     }
 
     /**

--- a/src/maybe.ts
+++ b/src/maybe.ts
@@ -185,6 +185,15 @@
  * right in the context of `Maybe`. This is useful for mapping, filtering, and
  * accumulating values using `Maybe`.
  *
+ * ## Lifting functions to work with `Maybe`
+ *
+ * The `lift` function receives an ordinary function that accepts arbitrary
+ * agruments, and returns an adapted function that accepts `Maybe` values as
+ * arguments instead. The arguments are evaluated from left to right, and if
+ * they are all `Just` variants, the original function is applied to their
+ * values and returned in a `Just`. If any `Maybe` is `Nothing`, `Nothing` is
+ * returned instead.
+ *
  * @example Basic matching and unwrapping
  *
  * ```ts
@@ -499,6 +508,15 @@ export namespace Maybe {
             }
             return results as { [K in keyof T]: JustT<T[K]> };
         });
+    }
+
+    /**
+     * Lift a function of any arity into the context of `Maybe`.
+     */
+    export function lift<T extends readonly unknown[], A>(
+        f: (...args: T) => A,
+    ): (...maybes: { [K in keyof T]: Maybe<T[K]> }) => Maybe<A> {
+        return (...maybes) => collect(maybes).map((args) => f(...args));
     }
 
     /**

--- a/src/validation.ts
+++ b/src/validation.ts
@@ -148,6 +148,15 @@
  * -   `gather` turns a record or an object literal of `Validation` values
  *     inside out.
  *
+ * ## Lifting functions to work with `Validation`
+ *
+ * The `lift` function receives an ordinary function that accepts arbitrary
+ * agruments, and returns an adapted function that accepts `Validation` values
+ * as arguments instead. The arguments are evaluated from left to right, and if
+ * they all succeed, the original function is applied to their successes to
+ * succeed with the result. If any `Validation` fails, failures will begin
+ * accumulating instead.
+ *
  * @example Validating a single property
  *
  * First, our imports:
@@ -448,6 +457,21 @@ export namespace Validation {
             });
         }
         return acc;
+    }
+
+    /**
+     * Lift a function of any arity into the context of `Validation`.
+     */
+    export function lift<T extends readonly unknown[], A>(
+        f: (...args: T) => A,
+    ): <E extends Semigroup<E>>(
+        ...vdns: { [K in keyof T]: Validation<E, T[K]> }
+    ) => Validation<E, A> {
+        return (...vdns) =>
+            collect(vdns).map((args) => f(...(args as T))) as Validation<
+                any,
+                A
+            >;
     }
 
     /**

--- a/test/either_test.ts
+++ b/test/either_test.ts
@@ -87,6 +87,11 @@ describe("Either", () => {
         assert.deepEqual(t0, Either.right({ x: _2, y: _4 }));
     });
 
+    specify("Either.lift", () => {
+        const t0 = Either.lift(tuple<2, 4>)(mk("R", _1, _2), mk("R", _3, _4));
+        assert.deepEqual(t0, Either.right([_2, _4] as const));
+    });
+
     specify("Either.goAsync", async () => {
         const t0 = await Either.goAsync(async function* () {
             const x = yield* await mkA("L", _1, _2);
@@ -214,7 +219,7 @@ describe("Either", () => {
         assert.deepEqual(t1, [_2, _4]);
     });
 
-    specify("#bindLeft", () => {
+    specify("#recover", () => {
         const t0 = mk("L", _1, _2).recover((x) => mk("L", tuple(x, _3), _4));
         assert.deepEqual(t0, Either.left([_1, _3] as const));
 

--- a/test/eval_test.ts
+++ b/test/eval_test.ts
@@ -62,6 +62,11 @@ describe("Eval", () => {
         assert.deepEqual(t0.run(), { x: _1, y: _2 });
     });
 
+    specify("Eval.lift", () => {
+        const t0 = Eval.lift(tuple)(mk(_1), mk(_2));
+        assert.deepEqual(t0.run(), [_1, _2]);
+    });
+
     specify("#[Semigroup.cmb]", () => {
         fc.assert(
             fc.property(arbStr(), arbStr(), (x, y) => {

--- a/test/fn_test.ts
+++ b/test/fn_test.ts
@@ -1,6 +1,6 @@
 import { assert } from "chai";
 import * as fc from "fast-check";
-import { id, negate } from "../src/fn.js";
+import { id, negate, wrapCtor } from "../src/fn.js";
 
 describe("Functions", () => {
     specify("id", () => {
@@ -22,5 +22,14 @@ describe("Functions", () => {
         assert.strictEqual(f(2), true);
         assert.strictEqual(g(1), true);
         assert.strictEqual(g(2), false);
+    });
+
+    specify("wrapCtor", () => {
+        class Box<A> {
+            constructor(readonly val: A) {}
+        }
+        const fn = wrapCtor(Box);
+        const t0 = fn(1);
+        assert.deepEqual(t0, new Box(1));
     });
 });

--- a/test/ior_test.ts
+++ b/test/ior_test.ts
@@ -104,6 +104,11 @@ describe("Ior", () => {
         assert.deepEqual(t0, Ior.both(cmb(sa, sc), { x: _2, y: _4 }));
     });
 
+    specify("Ior.lift", () => {
+        const t0 = Ior.lift(tuple<2, 4>)(mk("B", sa, _2), mk("B", sc, _4));
+        assert.deepEqual(t0, Ior.both(cmb(sa, sc), [_2, _4] as const));
+    });
+
     specify("Ior.goAsync", async () => {
         const t0 = await Ior.goAsync(async function* () {
             const x = yield* await mkA("L", sa, _2);

--- a/test/maybe_test.ts
+++ b/test/maybe_test.ts
@@ -76,13 +76,18 @@ describe("Maybe", () => {
     });
 
     specify("Maybe.collect", () => {
-        const t1 = Maybe.collect([mk("J", _1), mk("J", _2)] as const);
-        assert.deepEqual(t1, Maybe.just([_1, _2] as const));
+        const t0 = Maybe.collect([mk("J", _1), mk("J", _2)] as const);
+        assert.deepEqual(t0, Maybe.just([_1, _2] as const));
     });
 
     specify("Maybe.gather", () => {
-        const t1 = Maybe.gather({ x: mk("J", _1), y: mk("J", _2) });
-        assert.deepEqual(t1, Maybe.just({ x: _1, y: _2 }));
+        const t0 = Maybe.gather({ x: mk("J", _1), y: mk("J", _2) });
+        assert.deepEqual(t0, Maybe.just({ x: _1, y: _2 }));
+    });
+
+    specify("Maybe.lift", () => {
+        const t0 = Maybe.lift(tuple)(mk("J", _1), mk("J", _2));
+        assert.deepEqual(t0, Maybe.just([_1, _2] as const));
     });
 
     specify("Maybe.goAsync", async () => {

--- a/test/validation_test.ts
+++ b/test/validation_test.ts
@@ -79,6 +79,14 @@ describe("Validation", () => {
         assert.deepEqual(t3, Validation.ok({ x: _2, y: _4 }));
     });
 
+    specify("Validation.lift", () => {
+        const t0 = Validation.lift(tuple<2, 4>)(
+            mk("Ok", sa, _2),
+            mk("Ok", sc, _4),
+        );
+        assert.deepEqual(t0, Validation.ok([_2, _4] as const));
+    });
+
     specify("#[Eq.eq]", () => {
         fc.assert(
             fc.property(arbNum(), arbNum(), (x, y) => {


### PR DESCRIPTION
This introduces the `lift` combinators for `Either`, `Eval`, `Ior`, `Maybe`, and `Validation`, as well as the `wrapCtor` utility function.