### PR TITLE
Remove the `flat` combinators

### DIFF
--- a/src/either.ts
+++ b/src/either.ts
@@ -760,14 +760,6 @@ export namespace Either {
         }
 
         /**
-         * If this `Either` succeeds with another `Either`, return the inner
-         * `Either`; otherwise, return this `Either` as is.
-         */
-        flat<E, E1, A>(this: Either<E, Either<E1, A>>): Either<E | E1, A> {
-            return this.flatMap(id);
-        }
-
-        /**
          * If this and that `Either` both succeed, apply a function to their
          * successes and succeed with the result; otherwise, return the first
          * failed `Either`.

--- a/src/eval.ts
+++ b/src/eval.ts
@@ -498,13 +498,6 @@ export class Eval<out A> {
     }
 
     /**
-     * If the outcome of this `Eval` is another `Eval`, return the inner `Eval`.
-     */
-    flat<A>(this: Eval<Eval<A>>): Eval<A> {
-        return this.flatMap(id);
-    }
-
-    /**
      * Apply a function to the outcomes of this and that `Eval` and return the
      * result in an `Eval`.
      */

--- a/src/ior.ts
+++ b/src/ior.ts
@@ -912,17 +912,6 @@ export namespace Ior {
         }
 
         /**
-         * If this `Ior` has a right-hand value and the value is another `Ior`,
-         * return the inner `Ior`. Accumulate the left-hand values of `Both`
-         * variants using their behavior as a semigroup. If either `Ior` is a
-         * `Left`, combine the left-hand value with any existing left-hand value
-         * and return the result in a `Left`.
-         */
-        flat<A extends Semigroup<A>, B>(this: Ior<A, Ior<A, B>>): Ior<A, B> {
-            return this.flatMap(id);
-        }
-
-        /**
          * If this and that `Ior` have a right-hand value, apply a function to
          * the values and return the result as a right-hand value. Accumulate
          * the left-hand values of `Both` variants using their behavior as a

--- a/src/maybe.ts
+++ b/src/maybe.ts
@@ -744,14 +744,6 @@ export namespace Maybe {
         }
 
         /**
-         * If this `Maybe` is present and contains another `Maybe`, return the
-         * inner `Maybe`; otherwise, return `Nothing`.
-         */
-        flat<A>(this: Maybe<Maybe<A>>): Maybe<A> {
-            return this.flatMap(id);
-        }
-
-        /**
          * If this and that `Maybe` are both present, apply a function to thier
          * values and return the result in a `Just`; otherwise, return
          * `Nothing`.

--- a/test/either_test.ts
+++ b/test/either_test.ts
@@ -252,11 +252,6 @@ describe("Either", () => {
         assert.deepEqual(t3, Either.right([_2, _4] as const));
     });
 
-    specify("#flat", () => {
-        const t0 = mk("R", _1, mk("R", _3, _4)).flat();
-        assert.deepEqual(t0, Either.right(_4));
-    });
-
     specify("#zipWith", () => {
         const t0 = mk("R", _1, _2).zipWith(mk("R", _3, _4), tuple);
         assert.deepEqual(t0, Either.right([_2, _4] as const));

--- a/test/eval_test.ts
+++ b/test/eval_test.ts
@@ -81,11 +81,6 @@ describe("Eval", () => {
         assert.deepEqual(t0.run(), [_1, _2]);
     });
 
-    specify("#flat", () => {
-        const t0 = mk(mk(_1)).flat();
-        assert.strictEqual(t0.run(), _1);
-    });
-
     specify("#zipWith", () => {
         const t0 = mk(_1).zipWith(mk(_2), tuple);
         assert.deepEqual(t0.run(), [_1, _2]);

--- a/test/ior_test.ts
+++ b/test/ior_test.ts
@@ -389,11 +389,6 @@ describe("Ior", () => {
         assert.deepEqual(t8, Ior.both(cmb(sa, sc), [_2, _4] as const));
     });
 
-    specify("#flat", () => {
-        const t0 = mk("B", sa, mk("B", sc, _2)).flat();
-        assert.deepEqual(t0, Ior.both(cmb(sa, sc), _2));
-    });
-
     specify("#zipWith", () => {
         const t0 = mk("B", sa, _2).zipWith(mk("B", sc, _4), tuple);
         assert.deepEqual(t0, Ior.both(cmb(sa, sc), [_2, _4] as const));

--- a/test/maybe_test.ts
+++ b/test/maybe_test.ts
@@ -249,11 +249,6 @@ describe("Maybe", () => {
         assert.deepEqual(t3, Maybe.just([_1, _2] as const));
     });
 
-    specify("#flat", () => {
-        const t0 = mk("J", mk("J", _1)).flat();
-        assert.deepEqual(t0, Maybe.just(_1));
-    });
-
     specify("#zipWith", () => {
         const t0 = mk("J", _1).zipWith(mk("J", _2), tuple);
         assert.deepEqual(t0, Maybe.just([_1, _2] as const));


### PR DESCRIPTION
Prefer `flatMap` with `id` instead.