### PR TITLE
Remove the semigroup behavior from `Reverse`

### DIFF
--- a/src/cmp.ts
+++ b/src/cmp.ts
@@ -134,8 +134,8 @@
  *
  * ## Reversing order
  *
- * The `Reverse` class reverses the order of an underlying `Ord` value, and
- * provides pass-through implementations for `Eq` and `Semigroup`.
+ * The `Reverse` class provides an implementation for `Ord` that reverses the 
+ * order of an underlying implementor of `Ord`.
  *
  * ## Working with generic equivalence relations and total orders
  *
@@ -179,7 +179,7 @@
  * @module
  */
 
-import { cmb, Semigroup } from "./cmb.js";
+import { Semigroup } from "./cmb.js";
 
 /**
  * An interface that provides evidence of an [equivalence relation].
@@ -1125,12 +1125,5 @@ export class Reverse<out A> {
 
     [Ord.cmp]<A extends Ord<A>>(this: Reverse<A>, that: Reverse<A>): Ordering {
         return cmp(this.val, that.val).reverse();
-    }
-
-    [Semigroup.cmb]<A extends Semigroup<A>>(
-        this: Reverse<A>,
-        that: Reverse<A>,
-    ): Reverse<A> {
-        return new Reverse(cmb(this.val, that.val));
     }
 }

--- a/test/cmp_test.ts
+++ b/test/cmp_test.ts
@@ -21,14 +21,10 @@ import {
     Ordering,
     Reverse,
 } from "../src/cmp.js";
-import { arbNum, arbStr, Num, Str } from "./common.js";
+import { arbNum, Num } from "./common.js";
 
 function arbRevNum(): fc.Arbitrary<Reverse<Num>> {
     return arbNum().map((x) => new Reverse(x));
-}
-
-function arbRevStr(): fc.Arbitrary<Reverse<Str>> {
-    return arbStr().map((x) => new Reverse(x));
 }
 
 describe("Eq", () => {
@@ -428,14 +424,6 @@ describe("Reverse", () => {
         fc.assert(
             fc.property(arbRevNum(), arbRevNum(), (x, y) =>
                 assert.strictEqual(cmp(x, y), cmp(x.val, y.val).reverse()),
-            ),
-        );
-    });
-
-    specify("#[Semigroup.cmb]", () => {
-        fc.assert(
-            fc.property(arbRevStr(), arbRevStr(), (x, y) =>
-                assert.deepEqual(cmb(x, y), new Reverse(cmb(x.val, y.val))),
             ),
         );
     });


### PR DESCRIPTION
The `Reverse` helper should provide only a modified implementation for `Ord` and avoid prescribing unrelated behavior.