### PR TITLE
Correct and reword several parts of the documentation

### DIFF
--- a/src/cmb.ts
+++ b/src/cmb.ts
@@ -41,7 +41,7 @@
  *
  * ## Working with generic semigroups
  *
- * Often, code must be written to accept arbitrary semigroups. To require that
+ * Sometimes it is necessary to work with arbitrary semigroups. To require that
  * a generic type `A` implements `Semigroup`, we write `A extends Semigroup<A>`.
  *
  * @example Working with generic semigroups

--- a/src/cmp.ts
+++ b/src/cmp.ts
@@ -140,7 +140,7 @@
  *
  * ## Working with generic equivalence relations and total orders
  *
- * Often, code must be written to accept arbitrary equivalence relations and
+ * Sometimes it is necessary to work with arbitrary equivalence relations and
  * total orders. To require that a generic type `A` implements `Eq` or `Ord`, we
  * write `A extends Eq<A>` or `A extends Ord<A>`, respectively.
  *
@@ -402,7 +402,7 @@ import { Semigroup } from "./cmb.js";
  */
 export interface Eq<in A> {
     /**
-     * Test whether this and `Eq` value are equal.
+     * Test whether this and that `Eq` value are equal.
      */
     [Eq.eq](that: A): boolean;
 }
@@ -903,7 +903,7 @@ export function max<A extends Ord<A>>(x: A, y: A): A {
  *
  * @remarks
  *
- * `clamp(x, lo, hi)` is equivalent to `min(max(x, lo, hi))`.
+ * `clamp(x, lo, hi)` is equivalent to `min(max(x, lo), hi)`.
  */
 export function clamp<A extends Ord<A>>(x: A, lo: A, hi: A) {
     return min(max(x, lo), hi);

--- a/src/either.ts
+++ b/src/either.ts
@@ -29,12 +29,12 @@
  *
  * ### Handling failure with `Either`
  *
- * `Either` is also often used to represent a value which is either correct or a
- * failure. When using `Either` in this manner, the type is often written as
- * `Either<E, A>`, where:
+ * `Either` is also used to represent a value which is either a success or a
+ * failure. In this context, the type is written as `Either<E, A>` and its two
+ * variants are `Left<E>` and `Right<A>`.
  *
  * -   The `Left<E>` variant represents a *failed* `Either` and contains a
- *     *failure* of type `E`; and
+ *     *failure* of type `E`.
  * -   The `Right<A>` variant represents a *successful* `Either` and contains a
  *     *success* of type `A`.
  *

--- a/src/eval.ts
+++ b/src/eval.ts
@@ -15,7 +15,7 @@
  */
 
 /**
- * Control over synchronous execution.
+ * Control of synchronous execution.
  *
  * @remarks
  *


### PR DESCRIPTION
- Reword the docs for working with arbitrary equivalence relations, total orders, and semigroups
- Add a missing word to the docs for the `#[Eq.eq] method`
- Fix an incorrect example of the `clamp` function
- Reword the docs for using `Either` to handle failure