### PR TITLE
Remove the `bimap` combinators

### DIFF
--- a/src/either.ts
+++ b/src/either.ts
@@ -123,8 +123,6 @@
  *
  * These methods transform the value within an `Either`:
  *
- * -   `bimap` applies one of two functions to the value, depending on the
- *     variant.
  * -   `lmap` applies a function to the value in a left-sided `Either`.
  * -   `map` applies a function to the value in a right-sided `Either`.
  *
@@ -777,19 +775,6 @@ export namespace Either {
             that: Either<E1, B>,
         ): Either<E | E1, B> {
             return this.flatMap(() => that);
-        }
-
-        /**
-         * If this `Either` is left-sided, apply a function to its value and
-         * return the result in a `Left`; otherwise, apply a function to its
-         * value and return the result in a `Right`.
-         */
-        bimap<A, B, C, D>(
-            this: Either<A, B>,
-            lmap: (x: A) => C,
-            rmap: (x: B) => D,
-        ): Either<C, D> {
-            return this.isLeft() ? left(lmap(this.val)) : right(rmap(this.val));
         }
 
         /**

--- a/src/ior.ts
+++ b/src/ior.ts
@@ -130,8 +130,6 @@
  *
  * These methods transform the value(s) within an `Ior`:
  *
- * -   `bimap` applies one or two functions to the left-hand and/or the
- *     right-hand value(s), depending on the variant.
  * -   `lmap` applies a function to the left-hand value.
  * -   `map` applies a function to the left-hand value.
  *
@@ -952,25 +950,6 @@ export namespace Ior {
             that: Ior<A, C>,
         ): Ior<A, C> {
             return this.flatMap(() => that);
-        }
-
-        /**
-         * Apply two functions to the left-hand and/or right-hand values of this
-         * `Ior`, and return the result(s) as left-hand and right-hand values,
-         * respectively.
-         */
-        bimap<A, B, C, D>(
-            this: Ior<A, B>,
-            lmap: (x: A) => C,
-            rmap: (x: B) => D,
-        ): Ior<C, D> {
-            if (this.isLeft()) {
-                return left(lmap(this.val));
-            }
-            if (this.isRight()) {
-                return right(rmap(this.val));
-            }
-            return both(lmap(this.fst), rmap(this.snd));
         }
 
         /**

--- a/src/pair.ts
+++ b/src/pair.ts
@@ -75,10 +75,8 @@
  *
  * ## Transforming values
  *
- * These methods transform the first and/or second values within a `Pair`:
+ * These methods transform the first or the second value within a `Pair`:
  *
- * -   `bimap` applies two functions to the first and second values,
- *     respectively.
  * -   `lmap` applies a function to the first value.
  * -   `map` applies a function to the second value.
  *
@@ -139,14 +137,6 @@ export class Pair<out A, out B> {
      */
     unwrap<C>(f: (x: A, y: B) => C): C {
         return f(this.fst, this.snd);
-    }
-
-    /**
-     * Apply two functions to the first and second values of this `Pair`,
-     * respectively, and return a new `Pair` of the results.
-     */
-    bimap<C, D>(lmap: (x: A) => C, rmap: (x: B) => D): Pair<C, D> {
-        return new Pair(lmap(this.fst), rmap(this.snd));
     }
 
     /**

--- a/src/validation.ts
+++ b/src/validation.ts
@@ -120,8 +120,6 @@
  *
  * These methods transform the failure or the success within a `Validation`:
  *
- * -   `bimap` applies one of two functions to the failure or the success,
- *     depending on the variant.
  * -   `lmap` applies a function to the failure.
  * -   `map` applies a function to the success.
  *
@@ -600,19 +598,6 @@ export namespace Validation {
             that: Validation<E, B>,
         ): Validation<E, B> {
             return this.zipWith(that, (_, y) => y);
-        }
-
-        /**
-         * If this `Validation` fails, apply a function to its failure and fail
-         * with the result; otherwise, apply a function to its success and
-         * succeed with the result.
-         */
-        bimap<E, A, E1, B>(
-            this: Validation<E, A>,
-            lmap: (x: E) => E1,
-            rmap: (x: A) => B,
-        ): Validation<E1, B> {
-            return this.isErr() ? err(lmap(this.val)) : ok(rmap(this.val));
         }
 
         /**

--- a/test/either_test.ts
+++ b/test/either_test.ts
@@ -291,19 +291,5 @@ describe("either.js", () => {
             const t0 = t.left(_1, _2).lmap((x) => tuple(x, _3));
             assert.deepEqual(t0, Either.left([_1, _3] as const));
         });
-
-        specify("#bimap", () => {
-            const t1 = t.left(_1, _2).bimap(
-                (x) => tuple(x, _3),
-                (x) => tuple(x, _4),
-            );
-            assert.deepEqual(t1, Either.left([_1, _3] as const));
-
-            const t0 = t.right(_1, _2).bimap(
-                (x) => tuple(x, _3),
-                (x) => tuple(x, _4),
-            );
-            assert.deepEqual(t0, Either.right([_2, _4] as const));
-        });
     });
 });

--- a/test/ior_test.ts
+++ b/test/ior_test.ts
@@ -495,28 +495,5 @@ describe("ior.js", () => {
             const t2 = t.both(_1, _2).lmap((x) => tuple(x, _3));
             assert.deepEqual(t2, Ior.both([_1, _3] as const, _2));
         });
-
-        specify("#bimap", () => {
-            const t0 = t.left(_1, _2).bimap(
-                (x) => tuple(x, _3),
-                (x) => tuple(x, _4),
-            );
-            assert.deepEqual(t0, Ior.left([_1, _3] as const));
-
-            const t1 = t.right(_1, _2).bimap(
-                (x) => tuple(x, _3),
-                (x) => tuple(x, _4),
-            );
-            assert.deepEqual(t1, Ior.right([_2, _4] as const));
-
-            const t2 = t.both(_1, _2).bimap(
-                (x) => tuple(x, _3),
-                (x) => tuple(x, _4),
-            );
-            assert.deepEqual(
-                t2,
-                Ior.both([_1, _3] as const, [_2, _4] as const),
-            );
-        });
     });
 });

--- a/test/pair_test.ts
+++ b/test/pair_test.ts
@@ -62,17 +62,6 @@ describe("pair.js", () => {
             );
         });
 
-        specify("#bimap", () => {
-            const t0 = new Pair(_1, _2).bimap(
-                (x) => tuple(x, _3),
-                (x) => tuple(x, _4),
-            );
-            assert.deepEqual(
-                t0,
-                new Pair([_1, _3] as const, [_2, _4] as const),
-            );
-        });
-
         specify("#lmap", () => {
             const t0 = new Pair(_1, _2).lmap((x) => tuple(x, _3));
             assert.deepEqual(t0, new Pair([_1, _3] as const, _2));

--- a/test/validation_test.ts
+++ b/test/validation_test.ts
@@ -218,19 +218,5 @@ describe("validation.js", () => {
             const t1 = t.ok(_1, _2).lmap((x) => tuple(x, _3));
             assert.deepEqual(t1, Validation.ok(_2));
         });
-
-        specify("#bimap", () => {
-            const t0 = t.err(_1, _2).bimap(
-                (x) => tuple(x, _3),
-                (x) => tuple(x, _4),
-            );
-            assert.deepEqual(t0, Validation.err([_1, _3] as const));
-
-            const t1 = t.ok(_1, _2).bimap(
-                (x) => tuple(x, _3),
-                (x) => tuple(x, _4),
-            );
-            assert.deepEqual(t1, Validation.ok([_2, _4] as const));
-        });
     });
 });


### PR DESCRIPTION
Prefer only the `lmap` and `map` combinators instead.