### PR TITLE
Refactor tests to use BDD-style assertions

### DIFF
--- a/.github/workflows/run_tests.yml
+++ b/.github/workflows/run_tests.yml
@@ -31,11 +31,12 @@ jobs:
         with:
           node-version: ${{ matrix.node-version }}
       - run: npm ci
-      - run: npx mocha
+      - run: npx mocha --reporter dot
 
   test_ts:
     name: TypeScript v${{ matrix.ts-version }}
     runs-on: ubuntu-latest
+    continue-on-error: false
     strategy:
       matrix:
         ts-version:
@@ -47,4 +48,4 @@ jobs:
       - uses: volta-cli/action@v3
       - run: npm ci
       - run: npm i -D typescript@~${{ matrix.ts-version }}
-      - run: npx mocha
+      - run: npx mocha --reporter dot

--- a/test/cmb_test.ts
+++ b/test/cmb_test.ts
@@ -1,14 +1,14 @@
-import { assert } from "chai";
+import { expect } from "chai";
 import * as fc from "fast-check";
 import { cmb, Semigroup } from "../src/cmb.js";
-import { arb } from "./common.js";
+import { arbStr } from "./common.js";
 
 describe("cmb.js", () => {
     specify("cmb", () => {
         fc.assert(
-            fc.property(arb.str(), arb.str(), (x, y) =>
-                assert.deepEqual(cmb(x, y), x[Semigroup.cmb](y)),
-            ),
+            fc.property(arbStr(), arbStr(), (x, y) => {
+                expect(cmb(x, y)).to.deep.equal(x[Semigroup.cmb](y));
+            }),
         );
     });
 });

--- a/test/cmp_test.ts
+++ b/test/cmp_test.ts
@@ -255,9 +255,7 @@ describe("cmp.js", () => {
     specify("min", () => {
         fc.assert(
             fc.property(arbNum(), arbNum(), (x, y) => {
-                expect(min(x, y)).to.deep.equal(
-                    new Num(Math.min(x.val, y.val)),
-                );
+                expect(min(x, y)).to.equal(le(x, y) ? x : y);
             }),
         );
     });
@@ -265,9 +263,7 @@ describe("cmp.js", () => {
     specify("max", () => {
         fc.assert(
             fc.property(arbNum(), arbNum(), (x, y) => {
-                expect(max(x, y)).to.deep.equal(
-                    new Num(Math.max(x.val, y.val)),
-                );
+                expect(max(x, y)).to.equal(ge(x, y) ? x : y);
             }),
         );
     });
@@ -275,7 +271,7 @@ describe("cmp.js", () => {
     specify("clamp", () => {
         fc.assert(
             fc.property(arbNum(), arbNum(), arbNum(), (x, y, z) => {
-                expect(clamp(x, y, z)).to.deep.equal(min(max(x, y), z));
+                expect(clamp(x, y, z)).to.equal(min(max(x, y), z));
             }),
         );
     });

--- a/test/common.ts
+++ b/test/common.ts
@@ -1,4 +1,4 @@
-import { assert } from "chai";
+import { expect } from "chai";
 import * as fc from "fast-check";
 import { cmb, Semigroup } from "../src/cmb.js";
 import { cmp, Eq, eq, Ord, Ordering } from "../src/cmp.js";
@@ -29,50 +29,39 @@ export class Str implements Semigroup<Str> {
     }
 }
 
-export function tuple<A, B>(x: A, y: B): readonly [A, B] {
-    return [x, y] as const;
+export function arbNum(): fc.Arbitrary<Num> {
+    return fc.float({ noNaN: true }).map((x) => new Num(x));
 }
 
-export namespace arb {
-    export function float(): fc.Arbitrary<number> {
-        return fc.float({ noNaN: true });
-    }
+export function arbStr(): fc.Arbitrary<Str> {
+    return fc.string().map((x) => new Str(x));
+}
 
-    export function bigint(): fc.Arbitrary<bigint> {
-        return fc.bigInt();
-    }
-
-    export function num(): fc.Arbitrary<Num> {
-        return float().map((x) => new Num(x));
-    }
-
-    export function str(): fc.Arbitrary<Str> {
-        return fc.string().map((x) => new Str(x));
-    }
+export function tuple<T extends unknown[]>(...xs: T): T {
+    return xs;
 }
 
 describe("common.js", () => {
     describe("Num", () => {
         specify("#[Eq.eq]", () => {
             fc.assert(
-                fc.property(arb.num(), arb.num(), (x, y) =>
-                    assert.strictEqual(eq(x, y), x.val === y.val),
-                ),
+                fc.property(arbNum(), arbNum(), (x, y) => {
+                    expect(eq(x, y)).to.equal(x.val === y.val);
+                }),
             );
         });
 
         specify("#[Ord.cmp]", () => {
             fc.assert(
-                fc.property(arb.num(), arb.num(), (x, y) =>
-                    assert.strictEqual(
-                        cmp(x, y),
+                fc.property(arbNum(), arbNum(), (x, y) => {
+                    expect(cmp(x, y)).to.equal(
                         x.val < y.val
                             ? Ordering.less
                             : x.val > y.val
                             ? Ordering.greater
                             : Ordering.equal,
-                    ),
-                ),
+                    );
+                }),
             );
         });
     });
@@ -80,9 +69,9 @@ describe("common.js", () => {
     describe("Str", () => {
         specify("#[Semigroup.cmb]", () => {
             fc.assert(
-                fc.property(arb.str(), arb.str(), (x, y) =>
-                    assert.deepEqual(cmb(x, y), new Str(x.val + y.val)),
-                ),
+                fc.property(arbStr(), arbStr(), (x, y) => {
+                    expect(cmb(x, y)).to.deep.equal(new Str(x.val + y.val));
+                }),
             );
         });
     });

--- a/test/fn_test.ts
+++ b/test/fn_test.ts
@@ -1,4 +1,4 @@
-import { assert } from "chai";
+import { expect } from "chai";
 import * as fc from "fast-check";
 import { id, negatePred, wrapCtor } from "../src/fn.js";
 
@@ -7,29 +7,32 @@ describe("fn.js", () => {
         fc.assert(
             fc.property(
                 fc.anything().filter((x) => !Number.isNaN(x)),
-                (x) => assert.strictEqual(id(x), x),
+                (x) => {
+                    expect(id(x)).to.equal(x);
+                },
             ),
         );
     });
 
     specify("negatePred", () => {
-        function f(x: 1 | 2): x is 2 {
-            return x === 2;
+        function isOne(x: 1 | 2): boolean {
+            return x === 1;
         }
-        const g = negatePred(f);
+        const isNotOne = negatePred(isOne);
 
-        assert.strictEqual(f(1), false);
-        assert.strictEqual(f(2), true);
-        assert.strictEqual(g(1), true);
-        assert.strictEqual(g(2), false);
+        expect(isOne(1)).to.be.true;
+        expect(isOne(2)).to.be.false;
+        expect(isNotOne(1)).to.be.false;
+        expect(isNotOne(2)).to.be.true;
     });
 
     specify("wrapCtor", () => {
         class Box<A> {
             constructor(readonly val: A) {}
         }
-        const fn = wrapCtor(Box);
-        const t0 = fn(1);
-        assert.deepEqual(t0, new Box(1));
+        const f = wrapCtor(Box);
+
+        const result = f<1>(1);
+        expect(result).to.deep.equal(new Box(1));
     });
 });

--- a/test/pair_test.ts
+++ b/test/pair_test.ts
@@ -1,32 +1,33 @@
-import { assert } from "chai";
+import { expect } from "chai";
 import * as fc from "fast-check";
 import { cmb } from "../src/cmb.js";
 import { cmp, eq } from "../src/cmp.js";
 import { Pair } from "../src/pair.js";
-import { arb, tuple } from "./common.js";
-
-const _1 = 1 as const;
-const _2 = 2 as const;
-const _3 = 3 as const;
-const _4 = 4 as const;
+import { arbNum, arbStr, tuple } from "./common.js";
 
 describe("pair.js", () => {
     describe("Pair", () => {
+        specify("fromTuple", () => {
+            const result = Pair.fromTuple<1, 2>([1, 2]);
+            expect(result).to.deep.equal(new Pair(1, 2));
+        });
+
         specify("get#val", () => {
-            const t0 = new Pair(_1, _2).val;
-            assert.deepEqual(t0, [_1, _2]);
+            const result = new Pair<1, 2>(1, 2).val;
+            expect(result).to.deep.equal([1, 2]);
         });
 
         specify("#[Eq.eq]", () => {
             fc.assert(
                 fc.property(
-                    arb.num(),
-                    arb.num(),
-                    arb.num(),
-                    arb.num(),
+                    arbNum(),
+                    arbNum(),
+                    arbNum(),
+                    arbNum(),
                     (a, x, b, y) => {
-                        const t0 = eq(new Pair(a, x), new Pair(b, y));
-                        assert.strictEqual(t0, eq(a, b) && eq(x, y));
+                        expect(eq(new Pair(a, x), new Pair(b, y))).to.equal(
+                            eq(a, b) && eq(x, y),
+                        );
                     },
                 ),
             );
@@ -35,13 +36,14 @@ describe("pair.js", () => {
         specify("#[Ord.cmp]", () => {
             fc.assert(
                 fc.property(
-                    arb.num(),
-                    arb.num(),
-                    arb.num(),
-                    arb.num(),
+                    arbNum(),
+                    arbNum(),
+                    arbNum(),
+                    arbNum(),
                     (a, x, b, y) => {
-                        const t0 = cmp(new Pair(a, x), new Pair(b, y));
-                        assert.strictEqual(t0, cmb(cmp(a, b), cmp(x, y)));
+                        expect(cmp(new Pair(a, x), new Pair(b, y))).to.equal(
+                            cmb(cmp(a, b), cmp(x, y)),
+                        );
                     },
                 ),
             );
@@ -50,26 +52,32 @@ describe("pair.js", () => {
         specify("#[Semigroup.cmb]", () => {
             fc.assert(
                 fc.property(
-                    arb.str(),
-                    arb.str(),
-                    arb.str(),
-                    arb.str(),
+                    arbStr(),
+                    arbStr(),
+                    arbStr(),
+                    arbStr(),
                     (a, x, b, y) => {
-                        const t0 = cmb(new Pair(a, x), new Pair(b, y));
-                        assert.deepEqual(t0, new Pair(cmb(a, b), cmb(x, y)));
+                        expect(
+                            cmb(new Pair(a, x), new Pair(b, y)),
+                        ).to.deep.equal(new Pair(cmb(a, b), cmb(x, y)));
                     },
                 ),
             );
         });
 
+        specify("#unwrap", () => {
+            const result = new Pair<1, 2>(1, 2).unwrap(tuple);
+            expect(result).to.deep.equal([1, 2]);
+        });
+
         specify("#lmap", () => {
-            const t0 = new Pair(_1, _2).lmap((x) => tuple(x, _3));
-            assert.deepEqual(t0, new Pair([_1, _3] as const, _2));
+            const result = new Pair<1, 2>(1, 2).lmap((x): [1, 3] => [x, 3]);
+            expect(result).to.deep.equal(new Pair([1, 3], 2));
         });
 
         specify("#map", () => {
-            const t0 = new Pair(_1, _2).map((x) => tuple(x, _4));
-            assert.deepEqual(t0, new Pair(_1, [_2, _4] as const));
+            const result = new Pair<1, 2>(1, 2).map((x): [2, 4] => [x, 4]);
+            expect(result).to.deep.equal(new Pair(1, [2, 4]));
         });
     });
 });

--- a/test/validation_test.ts
+++ b/test/validation_test.ts
@@ -1,222 +1,276 @@
-import { assert } from "chai";
+import { expect } from "chai";
 import * as fc from "fast-check";
 import { cmb } from "../src/cmb.js";
 import { cmp, eq, Ordering } from "../src/cmp.js";
 import { Either } from "../src/either.js";
 import { Validation } from "../src/validation.js";
-import { arb, Str, tuple } from "./common.js";
-
-namespace t {
-    // eslint-disable-next-line @typescript-eslint/no-unused-vars
-    export function err<E, A>(x: E, _: A): Validation<E, A> {
-        return Validation.err(x);
-    }
-
-    export function ok<E, A>(_: E, y: A): Validation<E, A> {
-        return Validation.ok(y);
-    }
-}
-
-const _1 = 1 as const;
-const _2 = 2 as const;
-const _3 = 3 as const;
-const _4 = 4 as const;
-
-const str_a = new Str("a");
-const str_c = new Str("c");
+import { arbNum, arbStr, Str, tuple } from "./common.js";
 
 describe("validation.js", () => {
     describe("Validation", () => {
-        specify("fromEither", () => {
-            const t0 = Validation.fromEither(Either.left<1, 2>(_1));
-            assert.deepEqual(t0, Validation.err(_1));
+        describe("fromEither", () => {
+            it("returns an Err if the input is a Left", () => {
+                expect(
+                    Validation.fromEither(Either.left<1, 2>(1)),
+                ).to.deep.equal(Validation.err(1));
+            });
 
-            const t1 = Validation.fromEither(Either.right<2, 1>(_2));
-            assert.deepEqual(t1, Validation.ok(_2));
+            it("returns an Ok if the input is a Right", () => {
+                expect(
+                    Validation.fromEither(Either.right<2, 1>(2)),
+                ).to.deep.equal(Validation.ok(2));
+            });
         });
 
         specify("collect", () => {
-            const t0 = Validation.collect([
-                t.err(str_a, _2),
-                t.err(str_c, _4),
-            ] as const);
-            assert.deepEqual(t0, Validation.err(cmb(str_a, str_c)));
-
-            const t1 = Validation.collect([
-                t.err(str_a, _2),
-                t.ok(str_c, _4),
-            ] as const);
-            assert.deepEqual(t1, Validation.err(str_a));
-
-            const t2 = Validation.collect([
-                t.ok(str_a, _2),
-                t.err(str_c, _4),
-            ] as const);
-            assert.deepEqual(t2, Validation.err(str_c));
-
-            const t3 = Validation.collect([
-                t.ok(str_a, _2),
-                t.ok(str_c, _4),
-            ] as const);
-            assert.deepEqual(t3, Validation.ok([_2, _4] as const));
+            const inputs: [Validation<Str, 2>, Validation<Str, 4>] = [
+                Validation.ok(2),
+                Validation.ok(4),
+            ];
+            const result = Validation.collect(inputs);
+            expect(result).to.deep.equal(Validation.ok([2, 4]));
         });
 
         specify("gather", () => {
-            const t0 = Validation.gather({
-                x: t.err(str_a, _2),
-                y: t.err(str_c, _4),
+            const result = Validation.gather({
+                x: Validation.ok<2, Str>(2),
+                y: Validation.ok<4, Str>(4),
             });
-            assert.deepEqual(t0, Validation.err(cmb(str_a, str_c)));
-
-            const t1 = Validation.gather({
-                x: t.err(str_a, _2),
-                y: t.ok(str_c, _4),
-            });
-            assert.deepEqual(t1, Validation.err(str_a));
-
-            const t2 = Validation.gather({
-                x: t.ok(str_a, _2),
-                y: t.err(str_c, _4),
-            });
-            assert.deepEqual(t2, Validation.err(str_c));
-
-            const t3 = Validation.gather({
-                x: t.ok(str_a, _2),
-                y: t.ok(str_c, _4),
-            });
-            assert.deepEqual(t3, Validation.ok({ x: _2, y: _4 }));
+            expect(result).to.deep.equal(Validation.ok({ x: 2, y: 4 }));
         });
 
         specify("lift", () => {
-            const t0 = Validation.lift(tuple<2, 4>)(
-                t.ok(str_a, _2),
-                t.ok(str_c, _4),
+            const result = Validation.lift(tuple<[2, 4]>)(
+                Validation.ok(2),
+                Validation.ok(4),
             );
-            assert.deepEqual(t0, Validation.ok([_2, _4] as const));
+            expect(result).to.deep.equal(Validation.ok([2, 4]));
         });
 
-        specify("#[Eq.eq]", () => {
-            fc.assert(
-                fc.property(arb.num(), arb.num(), (x, y) => {
-                    const t0 = eq(Validation.err(x), Validation.err(y));
-                    assert.strictEqual(t0, eq(x, y));
+        describe("#[Eq.eq]", () => {
+            it("compares an Err and an Err by their failures", () => {
+                fc.assert(
+                    fc.property(arbNum(), arbNum(), (x, y) => {
+                        expect(
+                            eq(Validation.err(x), Validation.err(y)),
+                        ).to.equal(eq(x, y));
+                    }),
+                );
+            });
 
-                    const t1 = eq(Validation.err(x), Validation.ok(y));
-                    assert.strictEqual(t1, false);
+            it("compares an Err and an Ok as inequal", () => {
+                fc.assert(
+                    fc.property(arbNum(), arbNum(), (x, y) => {
+                        expect(eq(Validation.err(x), Validation.ok(y))).to.be
+                            .false;
+                    }),
+                );
+            });
 
-                    const t2 = eq(Validation.ok(x), Validation.err(y));
-                    assert.strictEqual(t2, false);
+            it("compares an Ok and an Err as inequal", () => {
+                fc.assert(
+                    fc.property(arbNum(), arbNum(), (x, y) => {
+                        expect(eq(Validation.ok(x), Validation.err(y))).to.be
+                            .false;
+                    }),
+                );
+            });
 
-                    const t3 = eq(Validation.ok(x), Validation.ok(y));
-                    assert.strictEqual(t3, eq(x, y));
-                }),
-            );
+            it("compares an Ok and an Ok by their successes", () => {
+                fc.assert(
+                    fc.property(arbNum(), arbNum(), (x, y) => {
+                        expect(eq(Validation.ok(x), Validation.ok(y))).to.equal(
+                            eq(x, y),
+                        );
+                    }),
+                );
+            });
         });
 
-        specify("#[Ord.cmp]", () => {
-            fc.assert(
-                fc.property(arb.num(), arb.num(), (x, y) => {
-                    const t0 = cmp(Validation.err(x), Validation.err(y));
-                    assert.strictEqual(t0, cmp(x, y));
+        describe("#[Ord.cmp]", () => {
+            it("compares an Err and an Err by their failures", () => {
+                fc.assert(
+                    fc.property(arbNum(), arbNum(), (x, y) => {
+                        expect(
+                            cmp(Validation.err(x), Validation.err(y)),
+                        ).to.equal(cmp(x, y));
+                    }),
+                );
+            });
 
-                    const t1 = cmp(Validation.err(x), Validation.ok(y));
-                    assert.strictEqual(t1, Ordering.less);
+            it("compares an Err as less than an Ok", () => {
+                fc.assert(
+                    fc.property(arbNum(), arbNum(), (x, y) => {
+                        expect(
+                            cmp(Validation.err(x), Validation.ok(y)),
+                        ).to.equal(Ordering.less);
+                    }),
+                );
+            });
 
-                    const t2 = cmp(Validation.ok(x), Validation.err(y));
-                    assert.strictEqual(t2, Ordering.greater);
+            it("compares an Ok as greater than an Err", () => {
+                fc.assert(
+                    fc.property(arbNum(), arbNum(), (x, y) => {
+                        expect(
+                            cmp(Validation.ok(x), Validation.err(y)),
+                        ).to.equal(Ordering.greater);
+                    }),
+                );
+            });
 
-                    const t3 = cmp(Validation.ok(x), Validation.ok(y));
-                    assert.strictEqual(t3, cmp(x, y));
-                }),
-            );
+            it("compares an Ok and an Ok by their successes", () => {
+                fc.assert(
+                    fc.property(arbNum(), arbNum(), (x, y) => {
+                        expect(
+                            cmp(Validation.ok(x), Validation.ok(y)),
+                        ).to.equal(cmp(x, y));
+                    }),
+                );
+            });
         });
 
         specify("#[Semigroup.cmb]", () => {
             fc.assert(
-                fc.property(arb.str(), arb.str(), (x, y) => {
-                    const t0 = cmb(Validation.err(x), Validation.err(y));
-                    assert.deepEqual(t0, Validation.err(cmb(x, y)));
-
-                    const t1 = cmb(Validation.err(x), Validation.ok(y));
-                    assert.deepEqual(t1, Validation.err(x));
-
-                    const t2 = cmb(Validation.ok(x), Validation.err(y));
-                    assert.deepEqual(t2, Validation.err(y));
-
-                    const t3 = cmb(Validation.ok(x), Validation.ok(y));
-                    assert.deepEqual(t3, Validation.ok(cmb(x, y)));
+                fc.property(arbStr(), arbStr(), (x, y) => {
+                    expect(
+                        cmb(Validation.ok(x), Validation.ok(y)),
+                    ).to.deep.equal(Validation.ok(cmb(x, y)));
                 }),
             );
         });
 
-        specify("#isErr", () => {
-            const t0 = t.err(_1, _2).isErr();
-            assert.strictEqual(t0, true);
+        describe("#isErr", () => {
+            it("returns true if the variant is Err", () => {
+                expect(Validation.err<1, 2>(1).isErr()).to.be.true;
+            });
 
-            const t1 = t.ok(_1, _2).isErr();
-            assert.strictEqual(t1, false);
+            it("returns false if the variant is Ok", () => {
+                expect(Validation.ok<2, 1>(2).isErr()).to.be.false;
+            });
         });
 
-        specify("#isOk", () => {
-            const t0 = t.err(_1, _2).isOk();
-            assert.strictEqual(t0, false);
+        describe("#isOk", () => {
+            it("returns false if the variant is Err", () => {
+                expect(Validation.err<1, 2>(1).isOk()).to.be.false;
+            });
 
-            const t1 = t.ok(_1, _2).isOk();
-            assert.strictEqual(t1, true);
+            it("returns true if the variant is Ok", () => {
+                expect(Validation.ok<2, 1>(2).isOk()).to.be.true;
+            });
         });
 
-        specify("#unwrap", () => {
-            const t0 = t.err(_1, _2).unwrap(
-                (x) => tuple(x, _3),
-                (x) => tuple(x, _4),
-            );
-            assert.deepEqual(t0, [_1, _3]);
+        describe("#unwrap", () => {
+            it("applies the first function if the variant is Err", () => {
+                const result = Validation.err<1, 2>(1).unwrap(
+                    (x): [1, 3] => [x, 3],
+                    (x): [2, 4] => [x, 4],
+                );
+                expect(result).to.deep.equal([1, 3]);
+            });
 
-            const t1 = t.ok(_1, _2).unwrap(
-                (x) => tuple(x, _3),
-                (x) => tuple(x, _4),
-            );
-            assert.deepEqual(t1, [_2, _4]);
+            it("applies the second function if the variant is Ok", () => {
+                const result = Validation.ok<2, 1>(2).unwrap(
+                    (x): [1, 3] => [x, 3],
+                    (x): [2, 4] => [x, 4],
+                );
+                expect(result).to.deep.equal([2, 4]);
+            });
         });
 
-        specify("#zipWith", () => {
-            const t0 = t.err(str_a, _2).zipWith(t.err(str_c, _4), tuple);
-            assert.deepEqual(t0, Validation.err(cmb(str_a, str_c)));
+        describe("#zipWith", () => {
+            it("combines the failures in a new Err if both values are Err", () => {
+                fc.assert(
+                    fc.property(arbStr(), arbStr(), (x, y) => {
+                        const result = Validation.err<Str, 2>(x).zipWith(
+                            Validation.err<Str, 4>(y),
+                            tuple,
+                        );
+                        expect(result).to.deep.equal(Validation.err(cmb(x, y)));
+                    }),
+                );
+            });
 
-            const t1 = t.err(str_a, _2).zipWith(t.ok(str_c, _4), tuple);
-            assert.deepEqual(t1, Validation.err(str_a));
+            it("returns the first Err if the second value is an Ok", () => {
+                fc.assert(
+                    fc.property(arbStr(), (x) => {
+                        const result = Validation.err<Str, 2>(x).zipWith(
+                            Validation.ok<4, Str>(4),
+                            tuple,
+                        );
+                        expect(result).to.deep.equal(Validation.err(x));
+                    }),
+                );
+            });
 
-            const t2 = t.ok(str_a, _2).zipWith(t.err(str_c, _4), tuple);
-            assert.deepEqual(t2, Validation.err(str_c));
+            it("returns the second Err if the first value is an Ok", () => {
+                fc.assert(
+                    fc.property(arbStr(), (y) => {
+                        const result = Validation.ok<2, Str>(2).zipWith(
+                            Validation.err<Str, 4>(y),
+                            tuple,
+                        );
+                        expect(result).to.deep.equal(Validation.err(y));
+                    }),
+                );
+            });
 
-            const t3 = t.ok(str_a, _2).zipWith(t.ok(str_c, _4), tuple);
-            assert.deepEqual(t3, Validation.ok([_2, _4] as const));
+            it("applies the function to the successes if both values are Ok", () => {
+                const result = Validation.ok<2, Str>(2).zipWith(
+                    Validation.ok<4, Str>(4),
+                    tuple,
+                );
+                expect(result).to.deep.equal(Validation.ok([2, 4]));
+            });
         });
 
         specify("#zipFst", () => {
-            const t0 = t.ok(str_a, _2).zipFst(t.ok(str_c, _4));
-            assert.deepEqual(t0, Validation.ok(_2));
+            const result = Validation.ok<2, Str>(2).zipFst(
+                Validation.ok<4, Str>(4),
+            );
+            expect(result).to.deep.equal(Validation.ok(2));
         });
 
         specify("#zipSnd", () => {
-            const t0 = t.ok(str_a, _2).zipSnd(t.ok(str_c, _4));
-            assert.deepEqual(t0, Validation.ok(_4));
+            const result = Validation.ok<2, Str>(2).zipSnd(
+                Validation.ok<4, Str>(4),
+            );
+            expect(result).to.deep.equal(Validation.ok(4));
         });
 
-        specify("#map", () => {
-            const t0 = t.err(_1, _2).map((x) => tuple(x, _4));
-            assert.deepEqual(t0, Validation.err(_1));
+        describe("#lmap", () => {
+            it("applies the function if the variant is Err", () => {
+                const result = Validation.err<1, 2>(1).lmap((x): [1, 3] => [
+                    x,
+                    3,
+                ]);
+                expect(result).to.deep.equal(Validation.err([1, 3]));
+            });
 
-            const t1 = t.ok(_1, _2).map((x) => tuple(x, _4));
-            assert.deepEqual(t1, Validation.ok([_2, _4] as const));
+            it("does not apply the function if the variant is Ok", () => {
+                const result = Validation.ok<2, 1>(2).lmap((x): [1, 3] => [
+                    x,
+                    3,
+                ]);
+                expect(result).to.deep.equal(Validation.ok(2));
+            });
         });
 
-        specify("#lmap", () => {
-            const t0 = t.err(_1, _2).lmap((x) => tuple(x, _3));
-            assert.deepEqual(t0, Validation.err([_1, _3] as const));
+        describe("#map", () => {
+            it("does not apply the function if the variant is Err", () => {
+                const result = Validation.err<1, 2>(1).map((x): [2, 4] => [
+                    x,
+                    4,
+                ]);
+                expect(result).to.deep.equal(Validation.err(1));
+            });
 
-            const t1 = t.ok(_1, _2).lmap((x) => tuple(x, _3));
-            assert.deepEqual(t1, Validation.ok(_2));
+            it("applies the function if the variant is Ok", () => {
+                const result = Validation.ok<2, 1>(2).map((x): [2, 4] => [
+                    x,
+                    4,
+                ]);
+                expect(result).to.deep.equal(Validation.ok([2, 4]));
+            });
         });
     });
 });


### PR DESCRIPTION
- Use `describe` and `it` blocks to declare expected behavior
- For Chai, Swap the `assert` API with the `expect` API