### PR TITLE
For `Either`, and `Maybe`, remove the `orElse` combinators

### DIFF
--- a/src/either.ts
+++ b/src/either.ts
@@ -719,17 +719,6 @@ export namespace Either {
         }
 
         /**
-         * If this `Either` fails, return a fallback `Either`; otherwise, return
-         * this `Either` as is.
-         */
-        orElse<A, E1, B>(
-            this: Either<any, A>,
-            that: Either<E1, B>,
-        ): Either<E1, A | B> {
-            return this.recover(() => that);
-        }
-
-        /**
          * If this `Either` succeeds, apply a function to its success to return
          * another `Either`; otherwise, return this `Either` as is.
          */

--- a/src/maybe.ts
+++ b/src/maybe.ts
@@ -166,8 +166,8 @@
  *
  * ## Recovering from `Nothing`
  *
- * The `orElse` method returns a fallback `Maybe` if absent, and does nothing if
- * present.
+ * The `recover` method evaluates a function to return a fallback `Maybe` if
+ * absent, and does nothing if present.
  *
  * ## Collecting into `Maybe`
  *
@@ -746,11 +746,11 @@ export namespace Maybe {
         }
 
         /**
-         * If this `Maybe` is absent, return a fallback `Maybe`; otherwise,
-         * return this `Maybe` as is.
+         * If this `Maybe` is absent, evaluate a function to return a fallback
+         * `Maybe`; otherwise, return this `Maybe` as is.
          */
-        orElse<A, B>(this: Maybe<A>, that: Maybe<B>): Maybe<A | B> {
-            return this.isNothing() ? that : this;
+        recover<A, B>(this: Maybe<A>, f: () => Maybe<B>): Maybe<A | B> {
+            return this.isNothing() ? f() : this;
         }
 
         /**

--- a/test/either_test.ts
+++ b/test/either_test.ts
@@ -261,11 +261,6 @@ describe("either.js", () => {
             });
         });
 
-        specify("#orElse", () => {
-            const result = Either.left<1, 2>(1).orElse(Either.right<4, 3>(4));
-            expect(result).to.deep.equal(Either.right(4));
-        });
-
         describe("#flatMap", () => {
             it("does not apply the continuation if the variant is Left", () => {
                 const result = Either.left<1, 2>(1).flatMap(

--- a/test/maybe_test.ts
+++ b/test/maybe_test.ts
@@ -305,14 +305,14 @@ describe("maybe.js", () => {
             });
         });
 
-        describe("#orElse", () => {
-            it("returns the other Maybe if the variant is Nothing", () => {
-                const result = nothing<1>().orElse(Maybe.just<2>(2));
+        describe("#recover", () => {
+            it("evaluates the function if the variant is Nothing", () => {
+                const result = nothing<1>().recover(() => Maybe.just<2>(2));
                 expect(result).to.deep.equal(Maybe.just(2));
             });
 
             it("returns a Just as is", () => {
-                const result = Maybe.just<1>(1).orElse(Maybe.just<2>(2));
+                const result = Maybe.just<1>(1).recover(() => Maybe.just<2>(2));
                 expect(result).to.deep.equal(Maybe.just(1));
             });
         });


### PR DESCRIPTION
- For `Either`, prefer use of `recover` instead.
- For `Maybe`, replace `orElse` with `recover`, which evaluates a function instead of accepting an eager argument.