### PR TITLE
Adjust some wording in the documentation

### DIFF
--- a/src/cmp.ts
+++ b/src/cmp.ts
@@ -503,7 +503,7 @@ export function ieq<A extends Eq<A>>(
  * -   reflexive: `le(x, x)`;
  * -   antisymmetric: `le(x, y)` and `le(y, x)` implies `eq(x, y)`;
  * -   transitive: `le(x, y)` and `le(y, z)` implies `le(x, z)`; and
- * -   comparable: either `le(x, y)` or `le(y, x)`
+ * -   comparable: `le(x, y)` or `le(y, x)`
  *
  * for all values `x`, `y`, and `z`.
  *

--- a/src/ior.ts
+++ b/src/ior.ts
@@ -674,7 +674,7 @@ export namespace Ior {
     }
 
     /**
-     * Turn a record or an object literal of elements "inside out".
+     * Turn a record or an object literal of `Ior` elements "inside out".
      *
      * @remarks
      *


### PR DESCRIPTION
- In the docs for the "comparable" corollary for `Ord`, remove the word "either" to not imply an "exclusive or" relationship.
- In the docs for `Ior.gather`, add a missing word.