### PR TITLE
Rename discriminator enumerations and properties

### DIFF
--- a/src/cmp.ts
+++ b/src/cmp.ts
@@ -105,7 +105,7 @@
  *
  * -   The `Less`, `Equal`, and `Greater` variant classes
  * -   The abstract `Syntax` class that provides the fluent API for `Ordering`
- * -   The `Typ` enumeration that discriminates `Ordering`
+ * -   The `Kind` enumeration that discriminates `Ordering`
  * -   The `less`, `equal`, and `greater` constants, which each represent their
  *     equivalent variant
  * -   The `fromNumber` function that constructs an `Ordering` from a `number`
@@ -919,15 +919,6 @@ export type Ordering = Ordering.Less | Ordering.Equal | Ordering.Greater;
  */
 export namespace Ordering {
     /**
-     * An enumeration that discriminates `Ordering`.
-     */
-    export enum Typ {
-        LESS,
-        EQUAL,
-        GREATER,
-    }
-
-    /**
      * Construct an `Ordering` from a `number` or a `bigint`.
      *
      * @remarks
@@ -954,11 +945,11 @@ export namespace Ordering {
      */
     export abstract class Syntax {
         [Eq.eq](this: Ordering, that: Ordering): boolean {
-            return this.typ === that.typ;
+            return this.kind === that.kind;
         }
 
         [Ord.cmp](this: Ordering, that: Ordering): Ordering {
-            return fromNumber(this.typ - that.typ);
+            return fromNumber(this.kind - that.kind);
         }
 
         [Semigroup.cmb](this: Ordering, that: Ordering): Ordering {
@@ -969,7 +960,7 @@ export namespace Ordering {
          * Test whether this `Ordering` is `Equal`.
          */
         isEq(this: Ordering): this is Equal {
-            return this.typ === Typ.EQUAL;
+            return this.kind === Kind.EQUAL;
         }
 
         /**
@@ -983,14 +974,14 @@ export namespace Ordering {
          * Test whether this `Ordering` is `Less`.
          */
         isLt(this: Ordering): this is Less {
-            return this.typ === Typ.LESS;
+            return this.kind === Kind.LESS;
         }
 
         /**
          * Test whether this `Ordering` is `Greater`.
          */
         isGt(this: Ordering): this is Greater {
-            return this.typ === Typ.GREATER;
+            return this.kind === Kind.GREATER;
         }
 
         /**
@@ -1047,6 +1038,15 @@ export namespace Ordering {
     }
 
     /**
+     * An enumeration that discriminates `Ordering`.
+     */
+    export enum Kind {
+        LESS,
+        EQUAL,
+        GREATER,
+    }
+
+    /**
      * An `Ordering` that indicates a "less than" comparison result.
      */
     export class Less extends Syntax {
@@ -1055,7 +1055,7 @@ export namespace Ordering {
         /**
          * The property that discriminates `Ordering`.
          */
-        readonly typ = Typ.LESS;
+        readonly kind = Kind.LESS;
 
         private constructor() {
             super();
@@ -1071,7 +1071,7 @@ export namespace Ordering {
         /**
          * The property that discriminates `Ordering`.
          */
-        readonly typ = Typ.EQUAL;
+        readonly kind = Kind.EQUAL;
 
         private constructor() {
             super();
@@ -1087,7 +1087,7 @@ export namespace Ordering {
         /**
          * The property that discriminates `Ordering`.
          */
-        readonly typ = Typ.GREATER;
+        readonly kind = Kind.GREATER;
 
         private constructor() {
             super();

--- a/src/either.ts
+++ b/src/either.ts
@@ -53,7 +53,7 @@
  *
  * -   The `Left` and `Right` variant classes
  * -   The abstract `Syntax` class that provides the fluent API for `Either`
- * -   The `Typ` enumeration that discriminates `Either`
+ * -   The `Kind` enumeration that discriminates `Either`
  * -   Functions for constructing, chaining, collecting into, and lifting into
  *     `Either`
  *
@@ -83,8 +83,8 @@
  * or right-sided, respectively. These methods also narrow the type of an
  * `Either` to the queried variant.
  *
- * The variant can also be queried and narrowed via the `typ` property, which
- * returns a member of the `Typ` enumeration.
+ * The variant can also be queried and narrowed via the `kind` property, which
+ * returns a member of the `Kind` enumeration.
  *
  * ## Extracting values
  *
@@ -207,12 +207,12 @@
  *     console.log(`Queried Right: ${strOrNum.val}`);
  * }
  *
- * // Querying and narrowing using the `typ` property
- * switch (strOrNum.typ) {
- *     case Either.Typ.LEFT:
+ * // Querying and narrowing using the `kind` property
+ * switch (strOrNum.kind) {
+ *     case Either.Kind.LEFT:
  *         console.log(`Matched Left: ${strOrNum.val}`);
  *         break;
- *     case Either.Typ.RIGHT:
+ *     case Either.Kind.RIGHT:
  *         console.log(`Matched Right: ${strOrNum.val}`);
  * }
  *
@@ -398,14 +398,6 @@ export type Either<A, B> = Either.Left<A> | Either.Right<B>;
  * The companion namespace for the `Either` type.
  */
 export namespace Either {
-    /**
-     * An enumeration that discriminates `Either`.
-     */
-    export enum Typ {
-        LEFT,
-        RIGHT,
-    }
-
     /**
      * Construct a left-sided `Either` from a value.
      */
@@ -685,14 +677,14 @@ export namespace Either {
          * Test whether this `Either` is left-sided.
          */
         isLeft<A>(this: Either<A, any>): this is Left<A> {
-            return this.typ === Typ.LEFT;
+            return this.kind === Kind.LEFT;
         }
 
         /**
          * Test whether this `Either` is right-sided.
          */
         isRight<B>(this: Either<any, B>): this is Right<B> {
-            return this.typ === Typ.RIGHT;
+            return this.kind === Kind.RIGHT;
         }
 
         /**
@@ -785,13 +777,21 @@ export namespace Either {
     }
 
     /**
+     * An enumeration that discriminates `Either`.
+     */
+    export enum Kind {
+        LEFT,
+        RIGHT,
+    }
+
+    /**
      * A left-sided Either.
      */
     export class Left<out A> extends Syntax {
         /**
          * The property that discriminates `Either`.
          */
-        readonly typ = Typ.LEFT;
+        readonly kind = Kind.LEFT;
 
         readonly val: A;
 
@@ -819,7 +819,7 @@ export namespace Either {
         /**
          * The property that discriminates `Either`.
          */
-        readonly typ = Typ.RIGHT;
+        readonly kind = Kind.RIGHT;
 
         readonly val: B;
 

--- a/src/eval.ts
+++ b/src/eval.ts
@@ -132,39 +132,39 @@
  * `Tree` data structure:
  *
  * ```ts
- * type Tree<A> = Tip | Bin<A>;
+ * type Tree<A> = Emtpty | Branch<A>;
  *
- * interface Tip {
- *     typ: "Tip";
+ * interface Empty {
+ *     readonly kind: "EMPTY";
  * }
  *
- * interface Bin<out A> {
- *     typ: "Bin";
- *     val: A;       // value
- *     lst: Tree<A>; // left subtree
- *     rst: Tree<A>; // right subtree
+ * interface Branch<out A> {
+ *     readonly kind: "BRANCH";
+ *     readonly val: A;       // value
+ *     readonly lst: Tree<A>; // left subtree
+ *     readonly rst: Tree<A>; // right subtree
  * }
  *
- * const tip: Tree<never> = { typ: "Tip" };
+ * const empty: Tree<never> = { kind: "EMPTY" };
  *
- * function bin<A>(val: A, lst: Tree<A>, rst: Tree<A>): Tree<A> {
- *     return { typ: "Bin", val, lst, rst };
+ * function branch<A>(val: A, lst: Tree<A>, rst: Tree<A>): Tree<A> {
+ *     return { kind: "BRANCH", val, lst, rst };
  * }
  *
  * function foldTree<A, B>(
  *     xs: Tree<A>,
- *     onTip: B,
- *     foldBin: (val: A, l: B, r: B) => B
+ *     onEmpty: B,
+ *     foldBranch: (val: A, l: B, r: B) => B
  * ): Eval<B> {
- *     if (xs.typ === "Tip") {
- *         return Eval.now(onTip);
+ *     if (xs.kind === "EMPTY") {
+ *         return Eval.now(onEmpty);
  *     }
  *     // Challenge for the reader: why is `defer` needed here?
  *     // Hint: it pertains to stack safety and eager evaluation.
  *     return Eval.defer(() =>
- *         foldTree(xs.lst, onTip, foldBin).flatMap((l) =>
- *             foldTree(xs.rst, onTip, foldBin).map((r) =>
- *                 foldBin(xs.val, l, r),
+ *         foldTree(xs.lst, onEmpty, foldBranch).flatMap((l) =>
+ *             foldTree(xs.rst, onEmpty, foldBranch).map((r) =>
+ *                 foldBranch(xs.val, l, r),
  *             ),
  *         ),
  *     );
@@ -174,10 +174,10 @@
  *     return foldTree(xs, [] as A[], (x, lxs, rxs) => [...lxs, x, ...rxs]);
  * }
  *
- * const oneToSeven: Tree<number> = bin(
+ * const oneToSeven: Tree<number> = branch(
  *     4,
- *     bin(2, bin(1, tip, tip), bin(3, tip, tip)),
- *     bin(6, bin(5, tip, tip), bin(7, tip, tip)),
+ *     branch(2, branch(1, empty, empty), branch(3, empty, empty)),
+ *     branch(6, branch(5, empty, empty), branch(7, empty, empty)),
  * );
  *
  * console.log(JSON.stringify(inOrder(oneToSeven).run()));
@@ -191,18 +191,18 @@
  * ```ts
  * function foldTree<A, B>(
  *     xs: Tree<A>,
- *     onTip: B,
- *     foldBin: (val: A, l: B, r: B) => B
+ *     onEmpty: B,
+ *     foldBranch: (val: A, l: B, r: B) => B
  * ): Eval<B> {
  *     return Eval.go(function* () {
- *         if (xs.typ === "Tip") {
- *             return onTip;
+ *         if (xs.kind === "EMPTY") {
+ *             return onEmpty;
  *         }
  *         // Challenge for the reader: why is `defer` not needed here?
  *         // Hint: it pertains to the behavior of `go`.
- *         const l = yield* foldTree(xs.lst, onTip, foldBin);
- *         const r = yield* foldTree(xs.rst, onTip, foldBin);
- *         return foldBin(xs.val, l, r);
+ *         const l = yield* foldTree(xs.lst, onEmpty, foldBranch);
+ *         const r = yield* foldTree(xs.rst, onEmpty, foldBranch);
+ *         return foldBranch(xs.val, l, r);
  *     });
  * }
  * ```

--- a/src/ior.ts
+++ b/src/ior.ts
@@ -51,7 +51,7 @@
  *
  * -   The `Left`, `Right`, and `Both` variant classes
  * -   The abstract `Syntax` class that provides the fluent API for `Ior`
- * -   The `Typ` enumeration that discriminates `Ior`
+ * -   The `Kind` enumeration that discriminates `Ior`
  * -   Functions for constructing, chaining, collecting into, and lifting into
  *     `Ior`
  *
@@ -83,8 +83,8 @@
  * a `Left`, a `Right`, or a `Both`, respectively. These methods also narrow the
  * type of an `Ior` to the queried variant.
  *
- * The variant can also be queried and narrowed via the `typ` property, which
- * returns a member of the `Typ` enumeration.
+ * The variant can also be queried and narrowed via the `kind` property, which
+ * returns a member of the `Kind` enumeration.
  *
  * ## Extracting values
  *
@@ -225,15 +225,15 @@
  *     console.log(`Queried Both: ${strIorNum.fst} and ${strIorNum.snd}`);
  * }
  *
- * // Querying and narrowing using the `typ` property
- * switch (strIorNum.typ) {
- *     case Ior.Typ.LEFT:
+ * // Querying and narrowing using the `kind` property
+ * switch (strIorNum.kind) {
+ *     case Ior.Kind.LEFT:
  *         console.log(`Matched Left: ${strIorNum.val}`);
  *         break;
- *     case Ior.Typ.RIGHT:
+ *     case Ior.Kind.RIGHT:
  *         console.log(`Matched Right: ${strIorNum.val}`);
  *         break;
- *     case Ior.Typ.BOTH:
+ *     case Ior.Kind.BOTH:
  *         console.log(`Matched Both: ${strIorNum.fst} and ${strIorNum.snd}`);
  * }
  *
@@ -467,15 +467,6 @@ export type Ior<A, B> = Ior.Left<A> | Ior.Right<B> | Ior.Both<A, B>;
  * The companion namespace for the `Ior` type.
  */
 export namespace Ior {
-    /**
-     * An enumeration that discriminates `Ior`.
-     */
-    export enum Typ {
-        LEFT,
-        RIGHT,
-        BOTH,
-    }
-
     /**
      * Construct a `Left` variant of `Ior` from a value.
      */
@@ -859,21 +850,21 @@ export namespace Ior {
          * Test whether this `Ior` is the `Left` variant.
          */
         isLeft<A>(this: Ior<A, any>): this is Left<A> {
-            return this.typ === Typ.LEFT;
+            return this.kind === Kind.LEFT;
         }
 
         /**
          * Test whether this `Ior` is the `Right` variant.
          */
         isRight<B>(this: Ior<any, B>): this is Right<B> {
-            return this.typ === Typ.RIGHT;
+            return this.kind === Kind.RIGHT;
         }
 
         /**
          * Test whether this `Ior` is the `Both` variant.
          */
         isBoth<A, B>(this: Ior<A, B>): this is Both<A, B> {
-            return this.typ === Typ.BOTH;
+            return this.kind === Kind.BOTH;
         }
 
         /**
@@ -998,13 +989,22 @@ export namespace Ior {
     }
 
     /**
+     * An enumeration that discriminates `Ior`.
+     */
+    export enum Kind {
+        LEFT,
+        RIGHT,
+        BOTH,
+    }
+
+    /**
      * An `Ior` with a left-hand value.
      */
     export class Left<out A> extends Syntax {
         /**
          * The property that discriminates `Ior`.
          */
-        readonly typ = Typ.LEFT;
+        readonly kind = Kind.LEFT;
 
         readonly val: A;
 
@@ -1032,7 +1032,7 @@ export namespace Ior {
         /**
          * The property that discriminates `Ior`.
          */
-        readonly typ = Typ.RIGHT;
+        readonly kind = Kind.RIGHT;
 
         readonly val: B;
 
@@ -1060,7 +1060,7 @@ export namespace Ior {
         /**
          * The property that discriminates `Ior`.
          */
-        readonly typ = Typ.BOTH;
+        readonly kind = Kind.BOTH;
 
         readonly fst: A;
 

--- a/src/maybe.ts
+++ b/src/maybe.ts
@@ -45,7 +45,7 @@
  *
  * -   The `Nothing` and `Just` variant classes
  * -   The abstract `Syntax` class that provides the fluent API for `Maybe`
- * -   The `Typ` enumeration that discriminates `Maybe`
+ * -   The `Kind` enumeration that discriminates `Maybe`
  * -   The `nothing` constant
  * -   Functions for constructing, chaining, collecting into, and lifting into
  *     `Maybe`
@@ -83,8 +83,8 @@
  * present, respectively. These methods also narrow the type of a `Maybe` to the
  * queried variant.
  *
- * The variant can also be queried and narrowed via the `typ` property, which
- * returns a member of the `Typ` enumeration.
+ * The variant can also be queried and narrowed via the `kind` property, which
+ * returns a member of the `Kind` enumeration.
  *
  * ## Extracting values
  *
@@ -214,12 +214,12 @@
  *     console.log(`Queried Just: ${maybeNum.val}`);
  * }
  *
- * // Querying and narrowing using the `typ` property
- * switch (maybeNum.typ) {
- *     case Maybe.Typ.NOTHING:
+ * // Querying and narrowing using the `kind` property
+ * switch (maybeNum.kind) {
+ *     case Maybe.Kind.NOTHING:
  *         console.log("Matched Nothing");
  *         break;
- *     case Maybe.Typ.JUST:
+ *     case Maybe.Kind.JUST:
  *         console.log(`Matched Just: ${maybeNum.val}`);
  * }
  *
@@ -409,14 +409,6 @@ export type Maybe<A> = Maybe.Nothing | Maybe.Just<A>;
  * The companion namespace for the `Maybe` type.
  */
 export namespace Maybe {
-    /**
-     * An enumeration that discriminates `Maybe`.
-     */
-    export enum Typ {
-        NOTHING,
-        JUST,
-    }
-
     /**
      * Construct a present `Maybe` from a value.
      */
@@ -716,14 +708,14 @@ export namespace Maybe {
          * Test whether this `Maybe` is absent.
          */
         isNothing(this: Maybe<any>): this is Nothing {
-            return this.typ === Typ.NOTHING;
+            return this.kind === Kind.NOTHING;
         }
 
         /**
          * Test whether this `Maybe` is present.
          */
         isJust<A>(this: Maybe<A>): this is Just<A> {
-            return this.typ === Typ.JUST;
+            return this.kind === Kind.JUST;
         }
 
         /**
@@ -811,6 +803,14 @@ export namespace Maybe {
     }
 
     /**
+     * An enumeration that discriminates `Maybe`.
+     */
+    export enum Kind {
+        NOTHING,
+        JUST,
+    }
+
+    /**
      * An absent `Maybe`.
      */
     export class Nothing extends Syntax {
@@ -819,7 +819,7 @@ export namespace Maybe {
         /**
          * The property that discriminates Maybe.
          */
-        readonly typ = Typ.NOTHING;
+        readonly kind = Kind.NOTHING;
 
         private constructor() {
             super();
@@ -844,7 +844,7 @@ export namespace Maybe {
         /**
          * The property that discriminates `Maybe`.
          */
-        readonly typ = Typ.JUST;
+        readonly kind = Kind.JUST;
 
         readonly val: A;
 

--- a/src/validation.ts
+++ b/src/validation.ts
@@ -44,7 +44,7 @@
  *
  * -   The `Err` and `Ok` variant classes
  * -   The abstract `Syntax` class that provides the fluent API for `Validation`
- * -   The `Typ` enumeration that discriminates `Validation`
+ * -   The `Kind` enumeration that discriminates `Validation`
  * -   Functions for constructing, collecting into, and lifting into
  *     `Validation`
  *
@@ -77,8 +77,8 @@
  * succeeds, respectively. These methods also narrow the type of a `Validation`
  * to the queried variant.
  *
- * The variant can also be queried and narrowed via the `typ` property, which
- * returns a member of the `Typ` enumeration.
+ * The variant can also be queried and narrowed via the `kind` property, which
+ * returns a member of the `Kind` enumeration.
  *
  * ## Extracting values
  *
@@ -389,14 +389,6 @@ export type Validation<E, A> = Validation.Err<E> | Validation.Ok<A>;
  */
 export namespace Validation {
     /**
-     * An enumeration that discriminates `Validation`.
-     */
-    export enum Typ {
-        ERR,
-        OK,
-    }
-
-    /**
      * Construct a failed `Validation` from a value.
      */
     export function err<E, A = never>(x: E): Validation<E, A> {
@@ -539,14 +531,14 @@ export namespace Validation {
          * Test whether this `Validation` has failed.
          */
         isErr<E>(this: Validation<E, any>): this is Err<E> {
-            return this.typ === Typ.ERR;
+            return this.kind === Kind.ERR;
         }
 
         /**
          * Test whether this `Validation` has succeeded.
          */
         isOk<A>(this: Validation<any, A>): this is Ok<A> {
-            return this.typ === Typ.OK;
+            return this.kind === Kind.OK;
         }
 
         /**
@@ -621,13 +613,21 @@ export namespace Validation {
     }
 
     /**
+     * An enumeration that discriminates `Validation`.
+     */
+    export enum Kind {
+        ERR,
+        OK,
+    }
+
+    /**
      * A failed `Validation`.
      */
     export class Err<out E> extends Syntax {
         /**
          * The property that discriminates `Validation`.
          */
-        readonly typ = Typ.ERR;
+        readonly kind = Kind.ERR;
 
         readonly val: E;
 
@@ -644,7 +644,7 @@ export namespace Validation {
         /**
          * The property that discriminates `Validation`.
          */
-        readonly typ = Typ.OK;
+        readonly kind = Kind.OK;
 
         readonly val: A;
 

--- a/test/either_test.ts
+++ b/test/either_test.ts
@@ -29,7 +29,7 @@ describe("either.js", () => {
             it("constructs a Left variant", () => {
                 const either = Either.left<1, 2>(1);
                 expect(either).to.be.an.instanceOf(Either.Left);
-                expect(either.typ).to.equal(Either.Typ.LEFT);
+                expect(either.kind).to.equal(Either.Kind.LEFT);
                 expect(either.val).to.equal(1);
             });
         });
@@ -38,7 +38,7 @@ describe("either.js", () => {
             it("constructs a Right variant", () => {
                 const either = Either.right<2, 1>(2);
                 expect(either).to.be.an.instanceOf(Either.Right);
-                expect(either.typ).to.equal(Either.Typ.RIGHT);
+                expect(either.kind).to.equal(Either.Kind.RIGHT);
                 expect(either.val).to.equal(2);
             });
         });

--- a/test/ior_test.ts
+++ b/test/ior_test.ts
@@ -32,7 +32,7 @@ describe("ior.js", () => {
             it("constucts a Left variant", () => {
                 const ior = Ior.left<1, 2>(1);
                 expect(ior).to.be.an.instanceOf(Ior.Left);
-                expect(ior.typ).to.equal(Ior.Typ.LEFT);
+                expect(ior.kind).to.equal(Ior.Kind.LEFT);
                 expect(ior.val).to.equal(1);
             });
         });
@@ -41,7 +41,7 @@ describe("ior.js", () => {
             it("constructs a Right variant", () => {
                 const ior = Ior.right<2, 1>(2);
                 expect(ior).to.be.an.instanceOf(Ior.Right);
-                expect(ior.typ).to.equal(Ior.Typ.RIGHT);
+                expect(ior.kind).to.equal(Ior.Kind.RIGHT);
                 expect(ior.val).to.equal(2);
             });
         });
@@ -50,7 +50,7 @@ describe("ior.js", () => {
             it("constructs a Both variant", () => {
                 const ior = Ior.both<1, 2>(1, 2);
                 expect(ior).to.be.an.instanceOf(Ior.Both);
-                expect(ior.typ).to.equal(Ior.Typ.BOTH);
+                expect(ior.kind).to.equal(Ior.Kind.BOTH);
                 expect((ior as Ior.Both<1, 2>).fst).to.equal(1);
                 expect((ior as Ior.Both<1, 2>).snd).to.equal(2);
                 expect(ior.val).to.deep.equal([1, 2]);

--- a/test/maybe_test.ts
+++ b/test/maybe_test.ts
@@ -28,7 +28,7 @@ describe("maybe.js", () => {
             it("represents the Nothing variant", () => {
                 const maybe: Maybe<1> = Maybe.nothing;
                 expect(maybe).to.be.an.instanceOf(Maybe.Nothing);
-                expect(maybe.typ).to.equal(Maybe.Typ.NOTHING);
+                expect(maybe.kind).to.equal(Maybe.Kind.NOTHING);
             });
         });
 
@@ -36,7 +36,7 @@ describe("maybe.js", () => {
             it("constructs a Just variant", () => {
                 const maybe = Maybe.just<1>(1);
                 expect(maybe).to.be.an.instanceOf(Maybe.Just);
-                expect(maybe.typ).to.equal(Maybe.Typ.JUST);
+                expect(maybe.kind).to.equal(Maybe.Kind.JUST);
                 expect((maybe as Maybe.Just<1>).val).to.equal(1);
             });
         });

--- a/test/validation_test.ts
+++ b/test/validation_test.ts
@@ -30,7 +30,7 @@ describe("validation.js", () => {
             it("constructs an Err variant", () => {
                 const vdn = Validation.err<1, 2>(1);
                 expect(vdn).to.be.an.instanceOf(Validation.Err);
-                expect(vdn.typ).to.equal(Validation.Typ.ERR);
+                expect(vdn.kind).to.equal(Validation.Kind.ERR);
                 expect(vdn.val).to.equal(1);
             });
         });
@@ -39,7 +39,7 @@ describe("validation.js", () => {
             it("constructs an Ok variant", () => {
                 const vdn = Validation.ok<2, 1>(2);
                 expect(vdn).to.be.an.instanceOf(Validation.Ok);
-                expect(vdn.typ).to.equal(Validation.Typ.OK);
+                expect(vdn.kind).to.equal(Validation.Kind.OK);
                 expect(vdn.val).to.equal(2);
             });
         });


### PR DESCRIPTION
- Rename `Typ` enumerations to `Kind`
- Rename `typ` discriminator properties to `kind`

Use `Kind` when referring to properties that discriminate union types. This is more descriptive and less obscure than using `typ`, and avoids any ambiguity with the `type` keyword.