### PR TITLE
Introduce the `goFn` and `goAsyncFn` functions

### DIFF
--- a/package.json
+++ b/package.json
@@ -107,6 +107,9 @@
             "@typescript-eslint/no-namespace": [
                 "off"
             ],
+            "no-inner-declarations": [
+                "off"
+            ],
             "quotes": [
                 "error",
                 "double"

--- a/src/eval.ts
+++ b/src/eval.ts
@@ -376,6 +376,24 @@ export class Eval<out A> {
     }
 
     /**
+     * Construct a function that returns an `Eval` using a generator
+     * comprehension.
+     *
+     * @remarks
+     *
+     * This is the higher-order function variant of `go`.
+     */
+    static goFn<T extends unknown[], A>(
+        f: (...args: T) => Generator<Eval<any>, A, unknown>,
+    ): (...args: T) => Eval<A> {
+        return (...args) =>
+            Eval.defer(() => {
+                const gen = f(...args);
+                return Eval.#step(gen, gen.next());
+            });
+    }
+
+    /**
      * Reduce a finite iterable from left to right in the context of `Eval`.
      *
      * @remarks

--- a/test/either_test.ts
+++ b/test/either_test.ts
@@ -75,6 +75,18 @@ describe("either.js", () => {
             });
         });
 
+        describe("goFn", () => {
+            it("accesses the parameters of the generator function", () => {
+                const f = Either.goFn(function* <A>(w: A) {
+                    const x = yield* Either.right<2, 1>(2);
+                    const [y, z] = yield* Either.right<[2, 4], 3>([x, 4]);
+                    return tuple(w, x, y, z);
+                });
+                const either = f<0>(0);
+                expect(either).to.deep.equal(Either.right([0, 2, 2, 4]));
+            });
+        });
+
         describe("reduce", () => {
             it("reduces the finite iterable from left to right in the context of Either", () => {
                 const either = Either.reduce(
@@ -157,6 +169,22 @@ describe("either.js", () => {
                     return Promise.resolve(tuple(x, y, z));
                 });
                 expect(either).to.deep.equal(Either.right([2, 2, 4]));
+            });
+        });
+
+        describe("goAsyncFn", () => {
+            it("accesses the parameters of the async generator function", async () => {
+                const f = Either.goAsyncFn(async function* <A>(w: A) {
+                    const x = yield* await Promise.resolve(
+                        Either.right<2, 1>(2),
+                    );
+                    const [y, z] = yield* await Promise.resolve(
+                        Either.right<[2, 4], 3>([x, 4]),
+                    );
+                    return tuple(w, x, y, z);
+                });
+                const either = await f<0>(0);
+                expect(either).to.deep.equal(Either.right([0, 2, 2, 4]));
             });
         });
 

--- a/test/eval_test.ts
+++ b/test/eval_test.ts
@@ -67,6 +67,19 @@ describe("eval.js", () => {
             });
         });
 
+        describe("goFn", () => {
+            it("accesses the parameters of the generator function", () => {
+                const f = Eval.goFn(function* <A>(w: A) {
+                    const x = yield* Eval.now<1>(1);
+                    const [y, z] = yield* Eval.now(tuple<[1, 2]>(x, 2));
+                    return tuple(w, x, y, z);
+                });
+                const ev = f<0>(0);
+                const outcome = ev.run();
+                expect(outcome).to.deep.equal([0, 1, 1, 2]);
+            });
+        });
+
         describe("reduce", () => {
             it("reduces the finite iterable from left to right in the context of Eval", () => {
                 const ev = Eval.reduce(

--- a/test/ior_test.ts
+++ b/test/ior_test.ts
@@ -145,6 +145,23 @@ describe("ior.js", () => {
             });
         });
 
+        describe("goFn", () => {
+            it("accesses the parameters of the generator function", () => {
+                const f = Ior.goFn(function* <A>(w: A) {
+                    const x = yield* Ior.both<Str, 2>(new Str("a"), 2);
+                    const [y, z] = yield* Ior.both(
+                        new Str("b"),
+                        tuple<[2, 4]>(x, 4),
+                    );
+                    return tuple(w, x, y, z);
+                });
+                const ior = f<0>(0);
+                expect(ior).to.deep.equal(
+                    Ior.both(new Str("ab"), [0, 2, 2, 4]),
+                );
+            });
+        });
+
         describe("reduce", () => {
             it("reduces the finite iterable from left to right in the context of Ior", () => {
                 const ior = Ior.reduce(
@@ -287,6 +304,24 @@ describe("ior.js", () => {
                     return Promise.resolve(tuple(x, y, z));
                 });
                 expect(ior).to.deep.equal(Ior.both(new Str("ab"), [2, 2, 4]));
+            });
+        });
+
+        describe("goAsyncFn", () => {
+            it("accesses the parameters of the async generator function", async () => {
+                const f = Ior.goAsyncFn(async function* <A>(w: A) {
+                    const x = yield* await Promise.resolve(
+                        Ior.both<Str, 2>(new Str("a"), 2),
+                    );
+                    const [y, z] = yield* await Promise.resolve(
+                        Ior.both(new Str("b"), tuple<[2, 4]>(x, 4)),
+                    );
+                    return tuple(w, x, y, z);
+                });
+                const ior = await f<0>(0);
+                expect(ior).to.deep.equal(
+                    Ior.both(new Str("ab"), [0, 2, 2, 4]),
+                );
             });
         });
 

--- a/test/maybe_test.ts
+++ b/test/maybe_test.ts
@@ -109,6 +109,18 @@ describe("maybe.js", () => {
             });
         });
 
+        describe("goFn", () => {
+            it("accesses the parameters of the generator function", () => {
+                const f = Maybe.goFn(function* <A>(w: A) {
+                    const x = yield* Maybe.just<1>(1);
+                    const [y, z] = yield* Maybe.just<[1, 2]>([x, 2]);
+                    return tuple(w, x, y, z);
+                });
+                const maybe = f<0>(0);
+                expect(maybe).to.deep.equal(Maybe.just([0, 1, 1, 2]));
+            });
+        });
+
         describe("reduce", () => {
             it("reduces the finite iterable from left to right in the context of Maybe", () => {
                 const maybe = Maybe.reduce(
@@ -185,6 +197,20 @@ describe("maybe.js", () => {
                     return Promise.resolve(tuple(x, y, z));
                 });
                 expect(maybe).to.deep.equal(Maybe.just([1, 1, 2]));
+            });
+        });
+
+        describe("goAsyncFn", () => {
+            it("accesses the parameters of the async generator function", async () => {
+                const f = Maybe.goAsyncFn(async function* <A>(w: A) {
+                    const x = yield* await Promise.resolve(Maybe.just<1>(1));
+                    const [y, z] = yield* await Promise.resolve(
+                        Maybe.just<[1, 2]>([x, 2]),
+                    );
+                    return tuple(w, x, y, z);
+                });
+                const maybe = await f<0>(0);
+                expect(maybe).to.deep.equal(Maybe.just([0, 1, 1, 2]));
             });
         });
 


### PR DESCRIPTION
This PR introduces:

- The `goFn` functions for `Either`, `Eval`, `Ior`, and `Maybe`
- The `goAsyncFn` functions for `Either`, `Ior`, and `Maybe`

These functions provide a higher-order function variant of generator comprehensions that allow the generators to specify zero or more parameters, and return a function that accepts those parameters and forwards them to the generator comprehension.