### PR TITLE
Provide better names for variables and parameters

### DIFF
--- a/src/cmb.ts
+++ b/src/cmb.ts
@@ -52,14 +52,14 @@
  * ```ts
  * import { cmb, Semigroup } from "@neotype/prelude/cmp.js";
  *
- * function cmbTimes<A extends Semigroup<A>>(x: A, n: number): A {
- *     if (n < 2 || n === Infinity) {
- *         return x;
+ * function cmbTimes<A extends Semigroup<A>>(val: A, times: number): A {
+ *     if (times < 2 || times === Infinity) {
+ *         return val;
  *     }
  *
- *     let acc = x;
- *     for (let i = 0; i < n; i++) {
- *         acc = cmb(acc, x);
+ *     let acc = val;
+ *     for (let i = 0; i < times; i++) {
+ *         acc = cmb(acc, val);
  *     }
  *     return acc;
  * }
@@ -190,7 +190,7 @@
  *         that: Async<A>,
  *     ): Async<A> {
  *         return new Async(
- *             this.val.then((x) => that.val.then((y) => cmb(x, y))),
+ *             this.val.then((lhs) => that.val.then((rhs) => cmb(lhs, rhs))),
  *         );
  *     }
  * }
@@ -300,8 +300,8 @@ export namespace Semigroup {
  *
  * @remarks
  *
- * `cmb(x, y)` is equivalent to `x[Semigroup.cmb](y)`.
+ * `cmb(lhs, rhs)` is equivalent to `lhs[Semigroup.cmb](rhs)`.
  */
-export function cmb<A extends Semigroup<A>>(x: A, y: A): A {
-    return x[Semigroup.cmb](y);
+export function cmb<A extends Semigroup<A>>(lhs: A, rhs: A): A {
+    return lhs[Semigroup.cmb](rhs);
 }

--- a/src/cmp.ts
+++ b/src/cmp.ts
@@ -152,9 +152,9 @@
  * ```ts
  * import { Eq, eq } from "@neotype/prelude/cmp.js";
  *
- * function singles<A extends Eq<A>>(xs: A[]): A[] {
- *     return xs.filter((x0, ix0) =>
- *         !xs.some((x1, ix1) => eq(x0, x1) && ix0 !== ix1),
+ * function singles<A extends Eq<A>>(vals: A[]): A[] {
+ *     return vals.filter((val0, idx0) =>
+ *         !vals.some((val1, idx1) => eq(val0, val1) && idx0 !== idx1),
  *     );
  * }
  * ```
@@ -167,8 +167,8 @@
  * ```ts
  * import { lt, Ord } from "@neotype/prelude/cmp.js";
  *
- * function filterLt<A extends Ord<A>>(xs: A[], y: A): A[] {
- *     return xs.filter((x) => lt(x, y));
+ * function filterLt<A extends Ord<A>>(vals: A[], input: A): A[] {
+ *     return vals.filter((val) => lt(val, input));
  * }
  * ```
  *
@@ -422,10 +422,10 @@ export namespace Eq {
  *
  * @remarks
  *
- * `eq(x, y)` is equivalent to `x[Eq.eq](y)`.
+ * `eq(lhs, rhs)` is equivalent to `lhs[Eq.eq](rhs)`.
  */
-export function eq<A extends Eq<A>>(x: A, y: A): boolean {
-    return x[Eq.eq](y);
+export function eq<A extends Eq<A>>(lhs: A, rhs: A): boolean {
+    return lhs[Eq.eq](rhs);
 }
 
 /**
@@ -433,10 +433,10 @@ export function eq<A extends Eq<A>>(x: A, y: A): boolean {
  *
  * @remarks
  *
- * `ne(x, y)` is equivalent to `!x[Eq.eq](y)`.
+ * `ne(lhs, rhs)` is equivalent to `!lhs[Eq.eq](rhs)`.
  */
-export function ne<A extends Eq<A>>(x: A, y: A): boolean {
-    return !x[Eq.eq](y);
+export function ne<A extends Eq<A>>(lhs: A, rhs: A): boolean {
+    return !lhs[Eq.eq](rhs);
 }
 
 /**
@@ -449,28 +449,28 @@ export function ne<A extends Eq<A>>(x: A, y: A): boolean {
  * lexicographically equal.
  */
 export function ieqBy<A>(
-    xs: Iterable<A>,
-    ys: Iterable<A>,
-    f: (x: A, y: A) => boolean,
+    lhs: Iterable<A>,
+    rhs: Iterable<A>,
+    eqBy: (lhs: A, rhs: A) => boolean,
 ): boolean {
-    const nxs = xs[Symbol.iterator]();
-    const nys = ys[Symbol.iterator]();
+    const lhsIter = lhs[Symbol.iterator]();
+    const rhsIter = rhs[Symbol.iterator]();
 
     for (
-        let nx = nxs.next(), ny = nys.next();
+        let lnxt = lhsIter.next(), rnxt = rhsIter.next();
         ;
-        nx = nxs.next(), ny = nys.next()
+        lnxt = lhsIter.next(), rnxt = rhsIter.next()
     ) {
-        if (!nx.done) {
-            if (!ny.done) {
-                if (!f(nx.value, ny.value)) {
+        if (!lnxt.done) {
+            if (!rnxt.done) {
+                if (!eqBy(lnxt.value, rnxt.value)) {
                     return false;
                 }
             } else {
                 return false;
             }
         } else {
-            return !!ny.done;
+            return !!rnxt.done;
         }
     }
 }
@@ -484,10 +484,10 @@ export function ieqBy<A>(
  * then the iterables are lexicographically equal.
  */
 export function ieq<A extends Eq<A>>(
-    xs: Iterable<A>,
-    ys: Iterable<A>,
+    lhs: Iterable<A>,
+    rhs: Iterable<A>,
 ): boolean {
-    return ieqBy(xs, ys, eq);
+    return ieqBy(lhs, rhs, eq);
 }
 
 /**
@@ -783,10 +783,10 @@ export namespace Ord {
  *
  * @remarks
  *
- * `cmp(x, y)` is equivalent to `x[Ord.cmp](y)`
+ * `cmp(lhs, rhs)` is equivalent to `lhs[Ord.cmp](rhs)`.
  */
-export function cmp<A extends Ord<A>>(x: A, y: A): Ordering {
-    return x[Ord.cmp](y);
+export function cmp<A extends Ord<A>>(lhs: A, rhs: A): Ordering {
+    return lhs[Ord.cmp](rhs);
 }
 
 /**
@@ -794,21 +794,21 @@ export function cmp<A extends Ord<A>>(x: A, y: A): Ordering {
  * ordering.
  */
 export function icmpBy<A>(
-    xs: Iterable<A>,
-    ys: Iterable<A>,
-    f: (x: A, y: A) => Ordering,
+    lhs: Iterable<A>,
+    rhs: Iterable<A>,
+    cmpBy: (lhs: A, rhs: A) => Ordering,
 ): Ordering {
-    const nxs = xs[Symbol.iterator]();
-    const nys = ys[Symbol.iterator]();
+    const lhsIter = lhs[Symbol.iterator]();
+    const rhsIter = rhs[Symbol.iterator]();
 
     for (
-        let nx = nxs.next(), ny = nys.next();
+        let lnxt = lhsIter.next(), rnxt = rhsIter.next();
         ;
-        nx = nxs.next(), ny = nys.next()
+        lnxt = lhsIter.next(), rnxt = rhsIter.next()
     ) {
-        if (!nx.done) {
-            if (!ny.done) {
-                const ordering = f(nx.value, ny.value);
+        if (!lnxt.done) {
+            if (!rnxt.done) {
+                const ordering = cmpBy(lnxt.value, rnxt.value);
                 if (ordering.isNe()) {
                     return ordering;
                 }
@@ -816,7 +816,7 @@ export function icmpBy<A>(
                 return Ordering.greater;
             }
         } else {
-            return ny.done ? Ordering.equal : Ordering.less;
+            return rnxt.done ? Ordering.equal : Ordering.less;
         }
     }
 }
@@ -826,10 +826,10 @@ export function icmpBy<A>(
  * ordering.
  */
 export function icmp<A extends Ord<A>>(
-    xs: Iterable<A>,
-    ys: Iterable<A>,
+    lhs: Iterable<A>,
+    rhs: Iterable<A>,
 ): Ordering {
-    return icmpBy(xs, ys, cmp);
+    return icmpBy(lhs, rhs, cmp);
 }
 
 /**
@@ -837,10 +837,10 @@ export function icmp<A extends Ord<A>>(
  *
  * @remarks
  *
- * Return `true` if `x` is less than `y`.
+ * Return `true` if `lhs` is less than `rhs`.
  */
-export function lt<A extends Ord<A>>(x: A, y: A): boolean {
-    return cmp(x, y).isLt();
+export function lt<A extends Ord<A>>(lhs: A, rhs: A): boolean {
+    return cmp(lhs, rhs).isLt();
 }
 
 /**
@@ -848,10 +848,10 @@ export function lt<A extends Ord<A>>(x: A, y: A): boolean {
  *
  * @remarks
  *
- * Return `true` if `x` is greater than `y`.
+ * Return `true` if `lhs` is greater than `rhs`.
  */
-export function gt<A extends Ord<A>>(x: A, y: A): boolean {
-    return cmp(x, y).isGt();
+export function gt<A extends Ord<A>>(lhs: A, rhs: A): boolean {
+    return cmp(lhs, rhs).isGt();
 }
 
 /**
@@ -859,10 +859,10 @@ export function gt<A extends Ord<A>>(x: A, y: A): boolean {
  *
  * @remarks
  *
- * Return `true` if `x` is less than or equal to `y`.
+ * Return `true` if `lhs` is less than or equal to `rhs`.
  */
-export function le<A extends Ord<A>>(x: A, y: A): boolean {
-    return cmp(x, y).isLe();
+export function le<A extends Ord<A>>(lhs: A, rhs: A): boolean {
+    return cmp(lhs, rhs).isLe();
 }
 
 /**
@@ -870,10 +870,10 @@ export function le<A extends Ord<A>>(x: A, y: A): boolean {
  *
  * @remarks
  *
- * Return `true` if `x` is greater than or equal to `y`.
+ * Return `true` if `lhs` is greater than or equal to `rhs`.
  */
-export function ge<A extends Ord<A>>(x: A, y: A): boolean {
-    return cmp(x, y).isGe();
+export function ge<A extends Ord<A>>(lhs: A, rhs: A): boolean {
+    return cmp(lhs, rhs).isGe();
 }
 
 /**
@@ -883,8 +883,8 @@ export function ge<A extends Ord<A>>(x: A, y: A): boolean {
  *
  * If the values are equal, return the first value.
  */
-export function min<A extends Ord<A>>(x: A, y: A): A {
-    return le(x, y) ? x : y;
+export function min<A extends Ord<A>>(lhs: A, rhs: A): A {
+    return le(lhs, rhs) ? lhs : rhs;
 }
 
 /**
@@ -894,8 +894,8 @@ export function min<A extends Ord<A>>(x: A, y: A): A {
  *
  * If the values are equal, return the first value.
  */
-export function max<A extends Ord<A>>(x: A, y: A): A {
-    return ge(x, y) ? x : y;
+export function max<A extends Ord<A>>(lhs: A, rhs: A): A {
+    return ge(lhs, rhs) ? lhs : rhs;
 }
 
 /**
@@ -903,10 +903,10 @@ export function max<A extends Ord<A>>(x: A, y: A): A {
  *
  * @remarks
  *
- * `clamp(x, lo, hi)` is equivalent to `min(max(x, lo), hi)`.
+ * `clamp(val, lo, hi)` is equivalent to `min(max(val, lo), hi)`.
  */
-export function clamp<A extends Ord<A>>(x: A, lo: A, hi: A) {
-    return min(max(x, lo), hi);
+export function clamp<A extends Ord<A>>(val: A, lo: A, hi: A) {
+    return min(max(val, lo), hi);
 }
 
 /**
@@ -930,11 +930,11 @@ export namespace Ordering {
      * An argument must never be `NaN`. This is the caller's responsibility to
      * enforce!
      */
-    export function fromNumber(n: number | bigint): Ordering {
-        if (n < 0) {
+    export function fromNumber(num: number | bigint): Ordering {
+        if (num < 0) {
             return less;
         }
-        if (n > 0) {
+        if (num > 0) {
             return greater;
         }
         return equal;

--- a/src/either.ts
+++ b/src/either.ts
@@ -401,15 +401,15 @@ export namespace Either {
     /**
      * Construct a left-sided `Either` from a value.
      */
-    export function left<A, B = never>(x: A): Either<A, B> {
-        return new Left(x);
+    export function left<A, B = never>(val: A): Either<A, B> {
+        return new Left(val);
     }
 
     /**
      * Construct a right-sided `Either` from a value.
      */
-    export function right<B, A = never>(x: B): Either<A, B> {
-        return new Right(x);
+    export function right<B, A = never>(val: B): Either<A, B> {
+        return new Right(val);
     }
 
     /**
@@ -470,27 +470,27 @@ export namespace Either {
      * ```ts
      * import { Either } from "@neotype/prelude/either.js";
      *
-     * const arg0: Either<string, number> = Either.right(1);
-     * const arg1: Either<string, number> = Either.right(2);
-     * const arg2: Either<string, number> = Either.right(3);
+     * const errOrOne: Either<string, number> = Either.right(1);
+     * const errOrTwo: Either<string, number> = Either.right(2);
+     * const errOrThree: Either<string, number> = Either.right(3);
      *
      * const summed: Either<string, number> = Either.go(function* () {
-     *     const x = yield* arg0;
-     *     const y = yield* arg1;
-     *     const z = yield* arg2;
+     *     const one = yield* errOrOne;
+     *     const two = yield* errOrTwo;
+     *     const three = yield* errOrThree;
      *
-     *     return x + y + z;
+     *     return one + two + three;
      * });
      *
      * console.log(summed.val); // 6
      * ```
      *
      * Now, observe the change in behavior if one of the yielded arguments was
-     * a failed `Either` instead. Replace the declaration of `arg1` with the
+     * a failed `Either` instead. Replace the declaration of `errOrTwo` with the
      * following and re-run the program.
      *
      * ```ts
-     * const arg1: Either<string, number> = Either.left("oops");
+     * const errOrTwo: Either<string, number> = Either.left("oops");
      * ```
      */
     export function go<T extends Either<any, any>, A>(
@@ -526,14 +526,14 @@ export namespace Either {
      * `Either`.
      */
     export function reduce<A, B, E>(
-        xs: Iterable<A>,
-        f: (acc: B, x: A) => Either<E, B>,
+        vals: Iterable<A>,
+        accum: (acc: B, val: A) => Either<E, B>,
         initial: B,
     ): Either<E, B> {
         return go(function* () {
             let acc = initial;
-            for (const x of xs) {
-                acc = yield* f(acc, x);
+            for (const val of vals) {
+                acc = yield* accum(acc, val);
             }
             return acc;
         });
@@ -735,10 +735,10 @@ export namespace Either {
          */
         unwrap<A, B, C, D>(
             this: Either<A, B>,
-            onLeft: (x: A) => C,
-            onRight: (x: B) => D,
+            unwrapLeft: (val: A) => C,
+            unwrapRight: (val: B) => D,
         ): C | D {
-            return this.isLeft() ? onLeft(this.val) : onRight(this.val);
+            return this.isLeft() ? unwrapLeft(this.val) : unwrapRight(this.val);
         }
 
         /**
@@ -747,7 +747,7 @@ export namespace Either {
          */
         recover<E, A, E1, B>(
             this: Either<E, A>,
-            f: (x: E) => Either<E1, B>,
+            f: (val: E) => Either<E1, B>,
         ): Either<E1, A | B> {
             return this.isLeft() ? f(this.val) : this;
         }
@@ -758,7 +758,7 @@ export namespace Either {
          */
         flatMap<E, A, E1, B>(
             this: Either<E, A>,
-            f: (x: A) => Either<E1, B>,
+            f: (val: A) => Either<E1, B>,
         ): Either<E | E1, B> {
             return this.isLeft() ? this : f(this.val);
         }
@@ -771,9 +771,9 @@ export namespace Either {
         zipWith<E, A, E1, B, C>(
             this: Either<E, A>,
             that: Either<E1, B>,
-            f: (x: A, y: B) => C,
+            f: (lhs: A, rhs: B) => C,
         ): Either<E | E1, C> {
-            return this.flatMap((x) => that.map((y) => f(x, y)));
+            return this.flatMap((lhs) => that.map((rhs) => f(lhs, rhs)));
         }
 
         /**
@@ -804,8 +804,8 @@ export namespace Either {
          * If this `Either` is left-sided, apply a function to its value and
          * return the result in a `Left`; otherwise, return this `Either` as is.
          */
-        lmap<A, B, C>(this: Either<A, B>, f: (x: A) => C): Either<C, B> {
-            return this.recover((x) => left(f(x)));
+        lmap<A, B, C>(this: Either<A, B>, f: (val: A) => C): Either<C, B> {
+            return this.recover((val) => left(f(val)));
         }
 
         /**
@@ -813,8 +813,8 @@ export namespace Either {
          * return the result in a `Right`; otherwise, return this `Either` as
          * is.
          */
-        map<A, B, D>(this: Either<A, B>, f: (x: B) => D): Either<A, D> {
-            return this.flatMap((x) => right(f(x)));
+        map<A, B, D>(this: Either<A, B>, f: (val: B) => D): Either<A, D> {
+            return this.flatMap((val) => right(f(val)));
         }
     }
 

--- a/src/fn.ts
+++ b/src/fn.ts
@@ -23,8 +23,8 @@
 /**
  * The identity function.
  */
-export function id<A>(x: A): A {
-    return x;
+export function id<A>(val: A): A {
+    return val;
 }
 
 /**
@@ -35,16 +35,16 @@ export function id<A>(x: A): A {
  * This function is useful for eagerly memoizing a value that would otherwise be
  * suspended behind a function.
  */
-export function constant<A>(x: A): (...args: any[]) => A {
-    return () => x;
+export function constant<A>(val: A): (...args: any[]) => A {
+    return () => val;
 }
 
 /**
  * Adapt a predicate into an identical predicate that negates its result.
  */
 export function negatePred<A, A1 extends A>(
-    f: (x: A) => x is A1,
-): (x: A) => x is Exclude<A, A1>;
+    f: (val: A) => val is A1,
+): (val: A) => val is Exclude<A, A1>;
 
 export function negatePred<T extends unknown[]>(
     f: (...args: T) => boolean,

--- a/src/internal/mut_stack.ts
+++ b/src/internal/mut_stack.ts
@@ -17,17 +17,17 @@
 type Node<A> = undefined | readonly [A, Node<A>];
 
 export class MutStack<out A> {
-    #hd: Node<A> = undefined;
+    #head: Node<A>;
 
-    push(x: A): void {
-        this.#hd = [x, this.#hd];
+    push(val: A): void {
+        this.#head = [val, this.#head];
     }
 
     pop(): A | undefined {
-        if (this.#hd) {
-            const [x, xs] = this.#hd;
-            this.#hd = xs;
-            return x;
+        if (this.#head) {
+            const [val, rest] = this.#head;
+            this.#head = rest;
+            return val;
         }
         return;
     }

--- a/src/maybe.ts
+++ b/src/maybe.ts
@@ -412,8 +412,8 @@ export namespace Maybe {
     /**
      * Construct a present `Maybe` from a value.
      */
-    export function just<A>(x: A): Maybe<A> {
-        return new Just(x);
+    export function just<A>(val: A): Maybe<A> {
+        return new Just(val);
     }
 
     /**
@@ -425,8 +425,8 @@ export namespace Maybe {
      * If the value is `null` or `undefined`, return `Nothing`; otherwise,
      * return the value in a `Just`.
      */
-    export function fromMissing<A>(x: A | null | undefined): Maybe<A> {
-        return x === null || x === undefined ? nothing : just(x);
+    export function fromMissing<A>(val: A | null | undefined): Maybe<A> {
+        return val === null || val === undefined ? nothing : just(val);
     }
 
     /**
@@ -453,13 +453,13 @@ export namespace Maybe {
      * otherwise, return `Nothing`.
      */
     export function wrapPred<A, A1 extends A>(
-        f: (x: A) => x is A1,
-    ): (x: A) => Maybe<A1>;
+        f: (val: A) => val is A1,
+    ): (val: A) => Maybe<A1>;
 
-    export function wrapPred<A>(f: (x: A) => boolean): (x: A) => Maybe<A>;
+    export function wrapPred<A>(f: (val: A) => boolean): (val: A) => Maybe<A>;
 
-    export function wrapPred<A>(f: (x: A) => boolean): (x: A) => Maybe<A> {
-        return (x) => (f(x) ? just(x) : nothing);
+    export function wrapPred<A>(f: (val: A) => boolean): (val: A) => Maybe<A> {
+        return (val) => (f(val) ? just(val) : nothing);
     }
 
     function step<A>(gen: Generator<Maybe<any>, A, unknown>): Maybe<A> {
@@ -505,27 +505,27 @@ export namespace Maybe {
      * ```ts
      * import { Maybe } from "@neotype/prelude/maybe.js";
      *
-     * const arg0: Maybe<number> = Maybe.just(1);
-     * const arg1: Maybe<number> = Maybe.just(2);
-     * const arg2: Maybe<number> = Maybe.just(3);
+     * const maybeOne: Maybe<number> = Maybe.just(1);
+     * const maybeTwo: Maybe<number> = Maybe.just(2);
+     * const maybeThree: Maybe<number> = Maybe.just(3);
      *
      * const summed: Maybe<number> = Maybe.go(function* () {
-     *     const x = yield* arg0;
-     *     const y = yield* arg1;
-     *     const z = yield* arg2;
+     *     const one = yield* maybeOne;
+     *     const two = yield* maybeTwo;
+     *     const three = yield* maybeThree;
      *
-     *     return x + y + z;
+     *     return one + two + three;
      * });
      *
      * console.log(summed.getOr("Nothing")); // 6
      * ```
      *
      * Now, observe the change in behavior if one of the yielded arguments was
-     * an absent `Maybe` instead. Replace the declaration of `arg1` with the
+     * an absent `Maybe` instead. Replace the declaration of `maybeTwo` with the
      * following and re-run the program.
      *
      * ```ts
-     * const arg1: Maybe<number> = Maybe.nothing;
+     * const maybeTwo: Maybe<number> = Maybe.nothing;
      * ```
      */
     export function go<A>(
@@ -560,14 +560,14 @@ export namespace Maybe {
      * the final accumulator in a `Just`; otherwise, return `Nothing`.
      */
     export function reduce<A, B>(
-        xs: Iterable<A>,
-        f: (acc: B, x: A) => Maybe<B>,
+        vals: Iterable<A>,
+        accum: (acc: B, val: A) => Maybe<B>,
         initial: B,
     ): Maybe<B> {
         return go(function* () {
             let acc = initial;
-            for (const x of xs) {
-                acc = yield* f(acc, x);
+            for (const val of vals) {
+                acc = yield* accum(acc, val);
             }
             return acc;
         });
@@ -762,7 +762,7 @@ export namespace Maybe {
         unwrap<A, B, C>(
             this: Maybe<A>,
             onNothing: () => B,
-            onJust: (x: A) => C,
+            onJust: (val: A) => C,
         ): B | C {
             return this.isNothing() ? onNothing() : onJust(this.val);
         }
@@ -795,7 +795,7 @@ export namespace Maybe {
          * If this `Maybe` is present, apply a function to its value to return
          * another `Maybe`; otherwise, return `Nothing`.
          */
-        flatMap<A, B>(this: Maybe<A>, f: (x: A) => Maybe<B>): Maybe<B> {
+        flatMap<A, B>(this: Maybe<A>, f: (val: A) => Maybe<B>): Maybe<B> {
             return this.isNothing() ? this : f(this.val);
         }
 
@@ -807,9 +807,9 @@ export namespace Maybe {
         zipWith<A, B, C>(
             this: Maybe<A>,
             that: Maybe<B>,
-            f: (x: A, y: B) => C,
+            f: (lhs: A, rhs: B) => C,
         ): Maybe<C> {
-            return this.flatMap((x) => that.map((y) => f(x, y)));
+            return this.flatMap((lhs) => that.map((rhs) => f(lhs, rhs)));
         }
 
         /**
@@ -833,8 +833,8 @@ export namespace Maybe {
          * If this `Maybe` is present, apply a function to its value and return
          * the result in a `Just`; otherwise, return `Nothing`.
          */
-        map<A, B>(this: Maybe<A>, f: (x: A) => B): Maybe<B> {
-            return this.flatMap((x) => just(f(x)));
+        map<A, B>(this: Maybe<A>, f: (val: A) => B): Maybe<B> {
+            return this.flatMap((val) => just(f(val)));
         }
     }
 

--- a/src/pair.ts
+++ b/src/pair.ts
@@ -136,7 +136,7 @@ export class Pair<out A, out B> {
      * Apply a function to the first value and second value of this `Pair` and
      * return the result.
      */
-    unwrap<C>(f: (x: A, y: B) => C): C {
+    unwrap<C>(f: (fst: A, snd: B) => C): C {
         return f(this.fst, this.snd);
     }
 
@@ -144,7 +144,7 @@ export class Pair<out A, out B> {
      * Apply a function to the first value of this `Pair`, and return a new
      * `Pair` of the result and the existing second value.
      */
-    lmap<C>(f: (x: A) => C): Pair<C, B> {
+    lmap<C>(f: (val: A) => C): Pair<C, B> {
         return new Pair(f(this.fst), this.snd);
     }
 
@@ -152,7 +152,7 @@ export class Pair<out A, out B> {
      * Apply a function to the second value of this `Pair`, and return a new
      * `Pair` of the existing first value and the result.
      */
-    map<D>(f: (x: B) => D): Pair<A, D> {
+    map<D>(f: (val: B) => D): Pair<A, D> {
         return new Pair(this.fst, f(this.snd));
     }
 }


### PR DESCRIPTION
Avoid using generic variable and parameter names like `x` and `y` or `arg` in the source code and documentation. Use clearer, more case-specific names instead.