### PR TITLE
Choose better names for generic parameters

### DIFF
--- a/src/cmb.ts
+++ b/src/cmb.ts
@@ -42,7 +42,7 @@
  * ## Working with generic semigroups
  *
  * Sometimes it is necessary to work with arbitrary semigroups. To require that
- * a generic type `A` implements `Semigroup`, we write `A extends Semigroup<A>`.
+ * a generic type `T` implements `Semigroup`, we write `T extends Semigroup<T>`.
  *
  * @example Working with generic semigroups
  *
@@ -52,7 +52,7 @@
  * ```ts
  * import { cmb, Semigroup } from "@neotype/prelude/cmp.js";
  *
- * function cmbTimes<A extends Semigroup<A>>(val: A, times: number): A {
+ * function cmbTimes<T extends Semigroup<T>>(val: T, times: number): T {
  *     if (times < 2 || times === Infinity) {
  *         return val;
  *     }
@@ -162,10 +162,10 @@
  * ```ts
  * import { Semigroup } from "@neotype/prelude/cmb.js";
  *
- * class Concat<out A> {
- *     constructor(readonly val: A[]) {}
+ * class Concat<out T> {
+ *     constructor(readonly val: T[]) {}
  *
- *     [Semigroup.cmb](that: Concat<A>): Concat<A> {
+ *     [Semigroup.cmb](that: Concat<T>): Concat<T> {
  *         return new Concat([...this.val, ...that.val]);
  *     }
  * }
@@ -182,13 +182,13 @@
  * ```ts
  * import { cmb, Semigroup } from "@neotype/prelude/cmb.js";
  *
- * class Async<out A> {
- *     constructor(readonly val: Promise<A>) {}
+ * class Async<out T> {
+ *     constructor(readonly val: Promise<T>) {}
  *
- *     [Semigroup.cmb]<A extends Semigroup<A>>(
- *         this: Async<A>,
- *         that: Async<A>,
- *     ): Async<A> {
+ *     [Semigroup.cmb]<T extends Semigroup<T>>(
+ *         this: Async<T>,
+ *         that: Async<T>,
+ *     ): Async<T> {
  *         return new Async(
  *             this.val.then((lhs) => that.val.then((rhs) => cmb(lhs, rhs))),
  *         );
@@ -197,12 +197,12 @@
  * ```
  *
  * Notice the extra syntax when implementing `[Semigroup.cmb]`. We introduce
- * a *method-scoped* generic parameter `A` and require that it has a `Semigroup`
- * implementation by writing `A extends Semigroup<A>` (the name `A` is
+ * a *method-scoped* generic parameter `T` and require that it has a `Semigroup`
+ * implementation by writing `T extends Semigroup<T>` (the name `T` is
  * arbitrary).
  *
- * Then, we require that `this` and `that` are `Async<A>` where `A extends
- * Semigroup<A>`. This allows us to use `cmb` to implement our desired behavior.
+ * Then, we require that `this` and `that` are `Async<T>` where `T extends
+ * Semigroup<T>`. This allows us to use `cmb` to implement our desired behavior.
  *
  * @example Generic implementation with multiple `Semigroup` requirements
  *
@@ -278,11 +278,11 @@
  * [augmentation]:
  *     https://www.typescriptlang.org/docs/handbook/declaration-merging.html#module-augmentation
  */
-export interface Semigroup<in out A> {
+export interface Semigroup<in out T> {
     /**
      * Combine this and that `Semigroup` value using an associative operation.
      */
-    [Semigroup.cmb](that: A): A;
+    [Semigroup.cmb](that: T): T;
 }
 
 /**
@@ -302,6 +302,6 @@ export namespace Semigroup {
  *
  * `cmb(lhs, rhs)` is equivalent to `lhs[Semigroup.cmb](rhs)`.
  */
-export function cmb<A extends Semigroup<A>>(lhs: A, rhs: A): A {
+export function cmb<T extends Semigroup<T>>(lhs: T, rhs: T): T {
     return lhs[Semigroup.cmb](rhs);
 }

--- a/src/cmp.ts
+++ b/src/cmp.ts
@@ -141,8 +141,8 @@
  * ## Working with generic equivalence relations and total orders
  *
  * Sometimes it is necessary to work with arbitrary equivalence relations and
- * total orders. To require that a generic type `A` implements `Eq` or `Ord`, we
- * write `A extends Eq<A>` or `A extends Ord<A>`, respectively.
+ * total orders. To require that a generic type `T` implements `Eq` or `Ord`, we
+ * write `T extends Eq<T>` or `T extends Ord<T>`, respectively.
  *
  * @example Working with generic equivalence relations
  *
@@ -152,7 +152,7 @@
  * ```ts
  * import { Eq, eq } from "@neotype/prelude/cmp.js";
  *
- * function singles<A extends Eq<A>>(vals: A[]): A[] {
+ * function singles<T extends Eq<T>>(vals: T[]): T[] {
  *     return vals.filter((val0, idx0) =>
  *         !vals.some((val1, idx1) => eq(val0, val1) && idx0 !== idx1),
  *     );
@@ -167,7 +167,7 @@
  * ```ts
  * import { lt, Ord } from "@neotype/prelude/cmp.js";
  *
- * function filterLt<A extends Ord<A>>(vals: A[], input: A): A[] {
+ * function filterLt<T extends Ord<T>>(vals: T[], input: T): T[] {
  *     return vals.filter((val) => lt(val, input));
  * }
  * ```
@@ -293,10 +293,10 @@ import { Semigroup } from "./cmb.js";
  * ```ts
  * import { Eq } from "@neotype/prelude/cmp.js";
  *
- * class Len<out A> {
- *     constructor(readonly val: A[]) {}
+ * class Len<out T> {
+ *     constructor(readonly val: T[]) {}
  *
- *     [Eq.eq](that: Len<A>): boolean {
+ *     [Eq.eq](that: Len<T>): boolean {
  *         return this.val.length === that.val.length;
  *     }
  * }
@@ -313,20 +313,20 @@ import { Semigroup } from "./cmb.js";
  * ```ts
  * import { Eq, ieq } from "@neotype/prelude/cmp.js";
  *
- * class Arr<out A> {
- *     constructor(readonly val: A[]) {}
+ * class Arr<out T> {
+ *     constructor(readonly val: T[]) {}
  *
- *     [Eq.eq]<A extends Eq<A>>(this: Arr<A>, that: Arr<A>): boolean {
+ *     [Eq.eq]<T extends Eq<T>>(this: Arr<T>, that: Arr<T>): boolean {
  *         return ieq(this.val, that.val);
  *     }
  * }
  * ```
  *
  * Notice the extra syntax when implementing `[Eq.eq]`. We introduce a
- * *method-scoped* generic parameter `A` and require that it has an `Eq`
- * implementation by writing `A extends Eq<A>` (the name `A` is arbitrary).
+ * *method-scoped* generic parameter `T` and require that it has an `Eq`
+ * implementation by writing `T extends Eq<T>` (the name `T` is arbitrary).
  *
- * Then, we require that `this` and `that` are `Arr<A>` where `A extends Eq<A>`.
+ * Then, we require that `this` and `that` are `Arr<T>` where `T extends Eq<T>`.
  * This allows us to use `ieq` to implement our desired behavior.
  *
  * @example Generic implementation with multiple `Eq` requirements
@@ -400,11 +400,11 @@ import { Semigroup } from "./cmb.js";
  * [augmentation]:
  *     https://www.typescriptlang.org/docs/handbook/declaration-merging.html#module-augmentation
  */
-export interface Eq<in A> {
+export interface Eq<in T> {
     /**
      * Test whether this and that `Eq` value are equal.
      */
-    [Eq.eq](that: A): boolean;
+    [Eq.eq](that: T): boolean;
 }
 
 /**
@@ -424,7 +424,7 @@ export namespace Eq {
  *
  * `eq(lhs, rhs)` is equivalent to `lhs[Eq.eq](rhs)`.
  */
-export function eq<A extends Eq<A>>(lhs: A, rhs: A): boolean {
+export function eq<T extends Eq<T>>(lhs: T, rhs: T): boolean {
     return lhs[Eq.eq](rhs);
 }
 
@@ -435,7 +435,7 @@ export function eq<A extends Eq<A>>(lhs: A, rhs: A): boolean {
  *
  * `ne(lhs, rhs)` is equivalent to `!lhs[Eq.eq](rhs)`.
  */
-export function ne<A extends Eq<A>>(lhs: A, rhs: A): boolean {
+export function ne<T extends Eq<T>>(lhs: T, rhs: T): boolean {
     return !lhs[Eq.eq](rhs);
 }
 
@@ -448,10 +448,10 @@ export function ne<A extends Eq<A>>(lhs: A, rhs: A): boolean {
  * determined to be equal by a provided function, the iterables are
  * lexicographically equal.
  */
-export function ieqBy<A>(
-    lhs: Iterable<A>,
-    rhs: Iterable<A>,
-    eqBy: (lhs: A, rhs: A) => boolean,
+export function ieqBy<T>(
+    lhs: Iterable<T>,
+    rhs: Iterable<T>,
+    eqBy: (lhs: T, rhs: T) => boolean,
 ): boolean {
     const lhsIter = lhs[Symbol.iterator]();
     const rhsIter = rhs[Symbol.iterator]();
@@ -483,9 +483,9 @@ export function ieqBy<A>(
  * If the iterables are the same length and their respective elements are equal,
  * then the iterables are lexicographically equal.
  */
-export function ieq<A extends Eq<A>>(
-    lhs: Iterable<A>,
-    rhs: Iterable<A>,
+export function ieq<T extends Eq<T>>(
+    lhs: Iterable<T>,
+    rhs: Iterable<T>,
 ): boolean {
     return ieqBy(lhs, rhs, eq);
 }
@@ -626,14 +626,14 @@ export function ieq<A extends Eq<A>>(
  * ```ts
  * import { Eq, Ord, Ordering } from "@neotype/prelude/cmp.js";
  *
- * class Len<out A> {
- *     constructor(readonly val: A[]) {}
+ * class Len<out T> {
+ *     constructor(readonly val: T[]) {}
  *
- *     [Eq.eq](that: Len<A>): boolean {
+ *     [Eq.eq](that: Len<T>): boolean {
  *         // An exercise for the reader...
  *     }
  *
- *     [Ord.cmp](that: Len<A>): Ordering {
+ *     [Ord.cmp](that: Len<T>): Ordering {
  *         return Ordering.fromNumber(this.val.length - that.val.length);
  *     }
  * }
@@ -650,25 +650,25 @@ export function ieq<A extends Eq<A>>(
  * ```ts
  * import { Eq, icmp, Ord, Ordering } from "@neotype/prelude/cmp.js";
  *
- * class Arr<out A> {
- *     constructor(readonly val: A[]) {}
+ * class Arr<out T> {
+ *     constructor(readonly val: T[]) {}
  *
- *     [Eq.eq]<A extends Eq<A>>(this: Arr<A>, that: Arr<A>): boolean {
+ *     [Eq.eq]<T extends Eq<T>>(this: Arr<T>, that: Arr<T>): boolean {
  *         // An exercise for the reader...
  *     }
  *
- *     [Ord.cmp]<A extends Ord<A>>(this: Arr<A>): Ordering {
+ *     [Ord.cmp]<T extends Ord<T>>(this: Arr<T>, that, Arr<T>): Ordering {
  *         return icmp(this.val, that.val);
  *     }
  * }
  * ```
  *
  * Notice the extra syntax when implementing `[Ord.cmp]`. We introduce a
- * *method-scoped* generic parameter `A` and require that it has an `Ord`
- * implementation by writing `A extends Ord<A>` (the name `A` is arbitrary).
+ * *method-scoped* generic parameter `T` and require that it has an `Ord`
+ * implementation by writing `T extends Ord<T>` (the name `T` is arbitrary).
  *
- * Then, we require that `this` and `that` are `Arr<A>` where `A extends
- * Ord<A>`. This allows us to use `icmp` to implement our desired behavior.
+ * Then, we require that `this` and `that` are `Arr<T>` where `T extends
+ * Ord<T>`. This allows us to use `icmp` to implement our desired behavior.
  *
  * @example Generic implementation with multiple `Ord` requirements
  *
@@ -761,11 +761,11 @@ export function ieq<A extends Eq<A>>(
  * [augmentation]:
  *     https://www.typescriptlang.org/docs/handbook/declaration-merging.html#module-augmentation
  */
-export interface Ord<in A> extends Eq<A> {
+export interface Ord<in T> extends Eq<T> {
     /**
      * Compare this and that `Ord` value to determine their ordering.
      */
-    [Ord.cmp](that: A): Ordering;
+    [Ord.cmp](that: T): Ordering;
 }
 
 /**
@@ -785,7 +785,7 @@ export namespace Ord {
  *
  * `cmp(lhs, rhs)` is equivalent to `lhs[Ord.cmp](rhs)`.
  */
-export function cmp<A extends Ord<A>>(lhs: A, rhs: A): Ordering {
+export function cmp<T extends Ord<T>>(lhs: T, rhs: T): Ordering {
     return lhs[Ord.cmp](rhs);
 }
 
@@ -793,10 +793,10 @@ export function cmp<A extends Ord<A>>(lhs: A, rhs: A): Ordering {
  * Compare two iterables of arbitrary values to determine their lexicographical
  * ordering.
  */
-export function icmpBy<A>(
-    lhs: Iterable<A>,
-    rhs: Iterable<A>,
-    cmpBy: (lhs: A, rhs: A) => Ordering,
+export function icmpBy<T>(
+    lhs: Iterable<T>,
+    rhs: Iterable<T>,
+    cmpBy: (lhs: T, rhs: T) => Ordering,
 ): Ordering {
     const lhsIter = lhs[Symbol.iterator]();
     const rhsIter = rhs[Symbol.iterator]();
@@ -825,9 +825,9 @@ export function icmpBy<A>(
  * Compare two iterables of `Ord` values to determine their lexicographical
  * ordering.
  */
-export function icmp<A extends Ord<A>>(
-    lhs: Iterable<A>,
-    rhs: Iterable<A>,
+export function icmp<T extends Ord<T>>(
+    lhs: Iterable<T>,
+    rhs: Iterable<T>,
 ): Ordering {
     return icmpBy(lhs, rhs, cmp);
 }
@@ -839,7 +839,7 @@ export function icmp<A extends Ord<A>>(
  *
  * Return `true` if `lhs` is less than `rhs`.
  */
-export function lt<A extends Ord<A>>(lhs: A, rhs: A): boolean {
+export function lt<T extends Ord<T>>(lhs: T, rhs: T): boolean {
     return cmp(lhs, rhs).isLt();
 }
 
@@ -850,7 +850,7 @@ export function lt<A extends Ord<A>>(lhs: A, rhs: A): boolean {
  *
  * Return `true` if `lhs` is greater than `rhs`.
  */
-export function gt<A extends Ord<A>>(lhs: A, rhs: A): boolean {
+export function gt<T extends Ord<T>>(lhs: T, rhs: T): boolean {
     return cmp(lhs, rhs).isGt();
 }
 
@@ -861,7 +861,7 @@ export function gt<A extends Ord<A>>(lhs: A, rhs: A): boolean {
  *
  * Return `true` if `lhs` is less than or equal to `rhs`.
  */
-export function le<A extends Ord<A>>(lhs: A, rhs: A): boolean {
+export function le<T extends Ord<T>>(lhs: T, rhs: T): boolean {
     return cmp(lhs, rhs).isLe();
 }
 
@@ -872,7 +872,7 @@ export function le<A extends Ord<A>>(lhs: A, rhs: A): boolean {
  *
  * Return `true` if `lhs` is greater than or equal to `rhs`.
  */
-export function ge<A extends Ord<A>>(lhs: A, rhs: A): boolean {
+export function ge<T extends Ord<T>>(lhs: T, rhs: T): boolean {
     return cmp(lhs, rhs).isGe();
 }
 
@@ -883,7 +883,7 @@ export function ge<A extends Ord<A>>(lhs: A, rhs: A): boolean {
  *
  * If the values are equal, return the first value.
  */
-export function min<A extends Ord<A>>(lhs: A, rhs: A): A {
+export function min<T extends Ord<T>>(lhs: T, rhs: T): T {
     return le(lhs, rhs) ? lhs : rhs;
 }
 
@@ -894,7 +894,7 @@ export function min<A extends Ord<A>>(lhs: A, rhs: A): A {
  *
  * If the values are equal, return the first value.
  */
-export function max<A extends Ord<A>>(lhs: A, rhs: A): A {
+export function max<T extends Ord<T>>(lhs: T, rhs: T): T {
     return ge(lhs, rhs) ? lhs : rhs;
 }
 
@@ -905,7 +905,7 @@ export function max<A extends Ord<A>>(lhs: A, rhs: A): A {
  *
  * `clamp(val, lo, hi)` is equivalent to `min(max(val, lo), hi)`.
  */
-export function clamp<A extends Ord<A>>(val: A, lo: A, hi: A) {
+export function clamp<T extends Ord<T>>(val: T, lo: T, hi: T) {
     return min(max(val, lo), hi);
 }
 
@@ -1113,18 +1113,18 @@ export namespace Ordering {
 /**
  * A helper type for reversing order.
  */
-export class Reverse<out A> {
-    readonly val: A;
+export class Reverse<out T> {
+    readonly val: T;
 
-    constructor(val: A) {
+    constructor(val: T) {
         this.val = val;
     }
 
-    [Eq.eq]<A extends Eq<A>>(this: Reverse<A>, that: Reverse<A>): boolean {
+    [Eq.eq]<T extends Eq<T>>(this: Reverse<T>, that: Reverse<T>): boolean {
         return eq(this.val, that.val);
     }
 
-    [Ord.cmp]<A extends Ord<A>>(this: Reverse<A>, that: Reverse<A>): Ordering {
+    [Ord.cmp]<T extends Ord<T>>(this: Reverse<T>, that: Reverse<T>): Ordering {
         return cmp(this.val, that.val).reverse();
     }
 }

--- a/src/fn.ts
+++ b/src/fn.ts
@@ -23,7 +23,7 @@
 /**
  * The identity function.
  */
-export function id<A>(val: A): A {
+export function id<T>(val: T): T {
     return val;
 }
 
@@ -35,32 +35,32 @@ export function id<A>(val: A): A {
  * This function is useful for eagerly memoizing a value that would otherwise be
  * suspended behind a function.
  */
-export function constant<A>(val: A): (...args: any[]) => A {
+export function constant<T>(val: T): (...args: any[]) => T {
     return () => val;
 }
 
 /**
  * Adapt a predicate into an identical predicate that negates its result.
  */
-export function negatePred<A, A1 extends A>(
-    f: (val: A) => val is A1,
-): (val: A) => val is Exclude<A, A1>;
+export function negatePred<T, T1 extends T>(
+    f: (val: T) => val is T1,
+): (val: T) => val is Exclude<T, T1>;
 
-export function negatePred<T extends unknown[]>(
-    f: (...args: T) => boolean,
-): (...args: T) => boolean;
+export function negatePred<TArgs extends unknown[]>(
+    f: (...args: TArgs) => boolean,
+): (...args: TArgs) => boolean;
 
-export function negatePred<T extends unknown[]>(
-    f: (...args: T) => boolean,
-): (...args: T) => boolean {
+export function negatePred<TArgs extends unknown[]>(
+    f: (...args: TArgs) => boolean,
+): (...args: TArgs) => boolean {
     return (...args) => !f(...args);
 }
 
 /**
  * Adapt a constructor into a callable function.
  */
-export function wrapCtor<T extends unknown[], A>(
-    ctor: new (...args: T) => A,
-): (...args: T) => A {
+export function wrapCtor<TArgs extends unknown[], T>(
+    ctor: new (...args: TArgs) => T,
+): (...args: TArgs) => T {
     return (...args) => new ctor(...args);
 }

--- a/src/internal/mut_stack.ts
+++ b/src/internal/mut_stack.ts
@@ -14,16 +14,16 @@
  * limitations under the License.
  */
 
-type Node<A> = undefined | readonly [A, Node<A>];
+type Node<T> = undefined | readonly [T, Node<T>];
 
-export class MutStack<out A> {
-    #head: Node<A>;
+export class MutStack<out T> {
+    #head: Node<T>;
 
-    push(val: A): void {
+    push(val: T): void {
         this.#head = [val, this.#head];
     }
 
-    pop(): A | undefined {
+    pop(): T | undefined {
         if (this.#head) {
             const [val, rest] = this.#head;
             this.#head = rest;

--- a/src/pair.ts
+++ b/src/pair.ts
@@ -136,7 +136,7 @@ export class Pair<out A, out B> {
      * Apply a function to the first value and second value of this `Pair` and
      * return the result.
      */
-    unwrap<C>(f: (fst: A, snd: B) => C): C {
+    unwrap<T>(f: (fst: A, snd: B) => T): T {
         return f(this.fst, this.snd);
     }
 
@@ -144,7 +144,7 @@ export class Pair<out A, out B> {
      * Apply a function to the first value of this `Pair`, and return a new
      * `Pair` of the result and the existing second value.
      */
-    lmap<C>(f: (val: A) => C): Pair<C, B> {
+    lmap<A1>(f: (val: A) => A1): Pair<A1, B> {
         return new Pair(f(this.fst), this.snd);
     }
 
@@ -152,7 +152,7 @@ export class Pair<out A, out B> {
      * Apply a function to the second value of this `Pair`, and return a new
      * `Pair` of the existing first value and the result.
      */
-    map<D>(f: (val: B) => D): Pair<A, D> {
+    map<B1>(f: (val: B) => B1): Pair<A, B1> {
         return new Pair(this.fst, f(this.snd));
     }
 }

--- a/src/validation.ts
+++ b/src/validation.ts
@@ -19,13 +19,13 @@
  *
  * @remarks
  *
- * `Validation<E, A>` is a type that represents a state of accumulated failure
- * or success. It is represented by two variants: `Err<E>` and `Ok<A>`.
+ * `Validation<E, T>` is a type that represents a state of accumulated failure
+ * or success. It is represented by two variants: `Err<E>` and `Ok<T>`.
  *
  * -   The `Err<E>` variant represents a *failed* `Validation` and contains a
  *     *failure* of type `E`.
- * -   The `Ok<A>` variant represents a *successful* `Validation` and contains a
- *     *success* of type `A`.
+ * -   The `Ok<T>` variant represents a *successful* `Validation` and contains a
+ *     *success* of type `T`.
  *
  * `Validation` is useful for collecting information about **all** failures in a
  * program, rather than halting evaluation on the first failure. This behavior
@@ -93,14 +93,14 @@
  *
  * `Validation` has the following behavior as an equivalence relation:
  *
- * -   A `Validation<E, A>` implements `Eq` when both `E` and `A` implement
+ * -   A `Validation<E, T>` implements `Eq` when both `E` and `T` implement
  *     `Eq`.
  * -   Two `Validation` values are equal if they are the same variant and their
  *     failures or successes are equal.
  *
  * `Validation` has the following behavior as a total order:
  *
- * -   A `Validation<E, A>` implements `Ord` when both `E` and `A` implement
+ * -   A `Validation<E, T>` implements `Ord` when both `E` and `T` implement
  *     `Ord`.
  * -   When ordered, a failed `Validation` always compares as less than any
  *     successful `Validation`. If the variants are the same, their failures or
@@ -110,7 +110,7 @@
  *
  * `Validation` has the following behavior as a semigroup:
  *
- * -   A `Validation<E, A>` implements `Semigroup` when both `E` and `A`
+ * -   A `Validation<E, T>` implements `Semigroup` when both `E` and `T`
  *     implement `Semigroup`.
  * -   When combined, a failed `Validation` ignores the combination and begins
  *     accumulating failures instead. If both succeed, their successes are
@@ -139,15 +139,15 @@
  *
  * -   `collect` turns an array or a tuple literal of `Validation` elements
  *     inside out. For example:
- *     -   `Validation<E, A>[]` becomes `Validation<E, A[]>`
- *     -   `[Validation<E, A>, Validation<E, B>]` becomes `Validation<E, [A,
- *         B]>`
+ *     -   `Validation<E, T>[]` becomes `Validation<E, T[]>`
+ *     -   `[Validation<E, T1>, Validation<E, T2>]` becomes `Validation<E, [T1,
+ *         T2]>`
  * -   `gather` turns a record or an object literal of `Validation` elements
  *     inside out. For example:
- *     -   `Record<string, Validation<E, A>>` becomes `Validation<E,
- *         Record<string, A>>`
- *     -   `{ x: Validation<E, A>, y: Validation<E, B> }` becomes `Validation<E,
- *         { x: A, y: B }>`
+ *     -   `Record<string, Validation<E, T>>` becomes `Validation<E,
+ *         Record<string, T>>`
+ *     -   `{ x: Validation<E, T1>, y: Validation<E, T2> }` becomes
+ *         `Validation<E, { x: T1, y: T2 }>`
  *
  * ## Lifting functions to work with `Validation`
  *
@@ -171,18 +171,18 @@
  *
  * ```ts
  * // A semigroup that wraps arrays
- * class List<out A> {
- *     readonly val: A[]
+ * class List<out T> {
+ *     readonly val: T[]
  *
- *     constructor(...vals: A[]) {
+ *     constructor(...vals: T[]) {
  *         this.val = vals;
  *     }
  *
- *     [Semigroup.cmb](that: List<A>): List<A> {
+ *     [Semigroup.cmb](that: List<T>): List<T> {
  *         return new List(...this.val, ...that.val);
  *     }
  *
- *     toJSON(): A[] {
+ *     toJSON(): T[] {
  *         return this.val;
  *     }
  * }
@@ -242,18 +242,18 @@
  *
  * ```ts
  * // A semigroup that wraps arrays
- * class List<out A> {
- *     readonly val: A[]
+ * class List<out T> {
+ *     readonly val: T[]
  *
- *     constructor(...vals: A[]) {
+ *     constructor(...vals: T[]) {
  *         this.val = vals;
  *     }
  *
- *     [Semigroup.cmb](that: List<A>): List<A> {
+ *     [Semigroup.cmb](that: List<T>): List<T> {
  *         return new List(...this.val, ...that.val);
  *     }
  *
- *     toJSON(): A[] {
+ *     toJSON(): T[] {
  *         return this.val;
  *     }
  * }
@@ -320,18 +320,18 @@
  *
  * ```ts
  * // A semigroup that wraps arrays
- * class List<out A> {
- *     readonly val: A[]
+ * class List<out T> {
+ *     readonly val: T[]
  *
- *     constructor(...vals: A[]) {
+ *     constructor(...vals: T[]) {
  *         this.val = vals;
  *     }
  *
- *     [Semigroup.cmb](that: List<A>): List<A> {
+ *     [Semigroup.cmb](that: List<T>): List<T> {
  *         return new List(...this.val, ...that.val);
  *     }
  *
- *     toJSON(): A[] {
+ *     toJSON(): T[] {
  *         return this.val;
  *     }
  * }
@@ -382,7 +382,7 @@ import { id } from "./fn.js";
 /**
  * A type that represents either accumulating failure (`Err`) or success (`Ok`).
  */
-export type Validation<E, A> = Validation.Err<E> | Validation.Ok<A>;
+export type Validation<E, T> = Validation.Err<E> | Validation.Ok<T>;
 
 /**
  * The companion namespace for the `Validation` type.
@@ -391,14 +391,14 @@ export namespace Validation {
     /**
      * Construct a failed `Validation` from a value.
      */
-    export function err<E, A = never>(val: E): Validation<E, A> {
+    export function err<E, T = never>(val: E): Validation<E, T> {
         return new Err(val);
     }
 
     /**
      * Construct a successful `Validation` from a value.
      */
-    export function ok<A, E = never>(val: A): Validation<E, A> {
+    export function ok<T, E = never>(val: T): Validation<E, T> {
         return new Ok(val);
     }
 
@@ -410,7 +410,7 @@ export namespace Validation {
      * If the `Either` is a `Left`, return its value in an `Err`; otherwise,
      * return its value in an `Ok`.
      */
-    export function fromEither<E, A>(either: Either<E, A>): Validation<E, A> {
+    export function fromEither<A, B>(either: Either<A, B>): Validation<A, B> {
         return either.unwrap(err, ok);
     }
 
@@ -426,13 +426,15 @@ export namespace Validation {
      *
      * For example:
      *
-     * -   `Validation<E, A>[]` becomes `Validation<E, A[]>`
-     * -   `[Validation<E, A>, Validation<E, B>]` becomes `Validation<E, [A,
-     *     B]>`
+     * -   `Validation<E, T>[]` becomes `Validation<E, T[]>`
+     * -   `[Validation<E, T1>, Validation<E, T2>]` becomes `Validation<E, [T1,
+     *     T2]>`
      */
     export function collect<
-        T extends readonly Validation<Semigroup<any>, any>[],
-    >(vdns: T): Validation<ErrT<T[number]>, { [K in keyof T]: OkT<T[K]> }> {
+        TVdns extends readonly Validation<Semigroup<any>, any>[],
+    >(
+        vdns: TVdns,
+    ): Validation<ErrT<TVdns[number]>, { [K in keyof TVdns]: OkT<TVdns[K]> }> {
         let acc = ok<any, any>(new Array(vdns.length));
         for (const [idx, vdn] of vdns.entries()) {
             acc = acc.zipWith(vdn, (results, val) => {
@@ -455,14 +457,19 @@ export namespace Validation {
      *
      * For example:
      *
-     * -   `Record<string, Validation<E, A>>` becomes `Validation<E,
-     *     Record<string, A>`
-     * -   `{ x: Validation<E, A>, y: Validation<E, B> }` becomes `Validation<E,
-     *     { x: A, y: B }>`
+     * -   `Record<string, Validation<E, T>>` becomes `Validation<E,
+     *     Record<string, T>>`
+     * -   `{ x: Validation<E, T1>, y: Validation<E, T2> }` becomes
+     *     `Validation<E, { x: T1, y: T2 }>`
      */
     export function gather<
-        T extends Record<string, Validation<Semigroup<any>, any>>,
-    >(vdns: T): Validation<ErrT<T[keyof T]>, { [K in keyof T]: OkT<T[K]> }> {
+        TVdns extends Record<string, Validation<Semigroup<any>, any>>,
+    >(
+        vdns: TVdns,
+    ): Validation<
+        ErrT<TVdns[keyof TVdns]>,
+        { [K in keyof TVdns]: OkT<TVdns[K]> }
+    > {
         let acc = ok<any, any>({});
         for (const [key, vdn] of Object.entries(vdns)) {
             acc = acc.zipWith(vdn, (results, val) => {
@@ -484,25 +491,25 @@ export namespace Validation {
      * original function to their successes and succeed with the result;
      * otherwise, begin accumulating failures on the first failed `Validation`.
      */
-    export function lift<T extends unknown[], A>(
-        f: (...args: T) => A,
+    export function lift<TArgs extends unknown[], T>(
+        f: (...args: TArgs) => T,
     ): <E extends Semigroup<E>>(
-        ...vdns: { [K in keyof T]: Validation<E, T[K]> }
-    ) => Validation<E, A> {
+        ...vdns: { [K in keyof TArgs]: Validation<E, TArgs[K]> }
+    ) => Validation<E, T> {
         // prettier-ignore
         return (...vdns) =>
             collect(vdns).map(
-                (args) => f(...(args as T))
-            ) as Validation<any, A>;
+                (args) => f(...(args as TArgs))
+            ) as Validation<any, T>;
     }
 
     /**
      * The fluent syntax for `Validation`.
      */
     export abstract class Syntax {
-        [Eq.eq]<E extends Eq<E>, A extends Eq<A>>(
-            this: Validation<E, A>,
-            that: Validation<E, A>,
+        [Eq.eq]<E extends Eq<E>, T extends Eq<T>>(
+            this: Validation<E, T>,
+            that: Validation<E, T>,
         ): boolean {
             if (this.isErr()) {
                 return that.isErr() && eq(this.val, that.val);
@@ -510,9 +517,9 @@ export namespace Validation {
             return that.isOk() && eq(this.val, that.val);
         }
 
-        [Ord.cmp]<E extends Ord<E>, A extends Ord<A>>(
-            this: Validation<E, A>,
-            that: Validation<E, A>,
+        [Ord.cmp]<E extends Ord<E>, T extends Ord<T>>(
+            this: Validation<E, T>,
+            that: Validation<E, T>,
         ): Ordering {
             if (this.isErr()) {
                 return that.isErr() ? cmp(this.val, that.val) : Ordering.less;
@@ -520,10 +527,10 @@ export namespace Validation {
             return that.isOk() ? cmp(this.val, that.val) : Ordering.greater;
         }
 
-        [Semigroup.cmb]<E extends Semigroup<E>, A extends Semigroup<A>>(
-            this: Validation<E, A>,
-            that: Validation<E, A>,
-        ): Validation<E, A> {
+        [Semigroup.cmb]<E extends Semigroup<E>, T extends Semigroup<T>>(
+            this: Validation<E, T>,
+            that: Validation<E, T>,
+        ): Validation<E, T> {
             return this.zipWith(that, cmb);
         }
 
@@ -537,18 +544,18 @@ export namespace Validation {
         /**
          * Test whether this `Validation` has succeeded.
          */
-        isOk<A>(this: Validation<any, A>): this is Ok<A> {
+        isOk<T>(this: Validation<any, T>): this is Ok<T> {
             return this.kind === Kind.OK;
         }
 
         /**
          * Case analysis for `Validation`.
          */
-        unwrap<E, A, B, B1>(
-            this: Validation<E, A>,
-            unwrapErr: (val: E) => B,
-            unwrapOk: (val: A) => B1,
-        ): B | B1 {
+        unwrap<E, T, T1, T2>(
+            this: Validation<E, T>,
+            unwrapErr: (val: E) => T1,
+            unwrapOk: (val: T) => T2,
+        ): T1 | T2 {
             return this.isErr() ? unwrapErr(this.val) : unwrapOk(this.val);
         }
 
@@ -557,11 +564,11 @@ export namespace Validation {
          * successes and succeed with the result; otherwise, begin accumulating
          * failures on the first failed `Validation`.
          */
-        zipWith<E extends Semigroup<E>, A, B, C>(
-            this: Validation<E, A>,
-            that: Validation<E, B>,
-            f: (lhs: A, rhs: B) => C,
-        ): Validation<E, C> {
+        zipWith<E extends Semigroup<E>, T, T1, T2>(
+            this: Validation<E, T>,
+            that: Validation<E, T1>,
+            f: (lhs: T, rhs: T1) => T2,
+        ): Validation<E, T2> {
             if (this.isErr()) {
                 return that.isErr() ? err(cmb(this.val, that.val)) : this;
             }
@@ -573,10 +580,10 @@ export namespace Validation {
          * first success and discard the second; otherwise, begin accumulating
          * failures on the first failed `Validation`.
          */
-        zipFst<E extends Semigroup<E>, A>(
-            this: Validation<E, A>,
+        zipFst<E extends Semigroup<E>, T>(
+            this: Validation<E, T>,
             that: Validation<E, any>,
-        ): Validation<E, A> {
+        ): Validation<E, T> {
             return this.zipWith(that, id);
         }
 
@@ -585,10 +592,10 @@ export namespace Validation {
          * second success and discard the first; otherwise, begin accumulating
          * failures on the first failed `Validation`.
          */
-        zipSnd<E extends Semigroup<E>, B>(
+        zipSnd<E extends Semigroup<E>, T1>(
             this: Validation<E, any>,
-            that: Validation<E, B>,
-        ): Validation<E, B> {
+            that: Validation<E, T1>,
+        ): Validation<E, T1> {
             return this.zipWith(that, (_, rhs) => rhs);
         }
 
@@ -596,10 +603,10 @@ export namespace Validation {
          * If this `Validation` fails, apply a function to its failure and fail
          * with the result; otherwise, return this `Validation` as is.
          */
-        lmap<E, A, E1>(
-            this: Validation<E, A>,
+        lmap<E, T, E1>(
+            this: Validation<E, T>,
             f: (val: E) => E1,
-        ): Validation<E1, A> {
+        ): Validation<E1, T> {
             return this.isErr() ? err(f(this.val)) : this;
         }
 
@@ -607,10 +614,10 @@ export namespace Validation {
          * If this `Validation` succeeds, apply a function to its success and
          * succeed with the result; otherwise, return this `Validation` as is.
          */
-        map<E, A, B>(
-            this: Validation<E, A>,
-            f: (val: A) => B,
-        ): Validation<E, B> {
+        map<E, T, T1>(
+            this: Validation<E, T>,
+            f: (val: T) => T1,
+        ): Validation<E, T1> {
             return this.isErr() ? this : ok(f(this.val));
         }
     }
@@ -643,31 +650,31 @@ export namespace Validation {
     /**
      * A successful `Validation`.
      */
-    export class Ok<out A> extends Syntax {
+    export class Ok<out T> extends Syntax {
         /**
          * The property that discriminates `Validation`.
          */
         readonly kind = Kind.OK;
 
-        readonly val: A;
+        readonly val: T;
 
-        constructor(val: A) {
+        constructor(val: T) {
             super();
             this.val = val;
         }
     }
 
     /**
-     * Extract the failure type `E` from the type `Validation<E, A>`.
+     * Extract the failure type `E` from the type `Validation<E, T>`.
      */
     // prettier-ignore
-    export type ErrT<T extends Validation<any, any>> =
-        [T] extends [Validation<infer E, any>] ? E : never;
+    export type ErrT<TVdn extends Validation<any, any>> =
+        [TVdn] extends [Validation<infer E, any>] ? E : never;
 
     /**
-     * Extract the success type `A` from the type `Validation<E, A>`.
+     * Extract the success type `T` from the type `Validation<E, T>`.
      */
     // prettier-ignore
-    export type OkT<T extends Validation<any, any>> =
-        [T] extends [Validation<any, infer A>] ? A : never;
+    export type OkT<TVdn extends Validation<any, any>> =
+        [TVdn] extends [Validation<any, infer T>] ? T : never;
 }

--- a/test/cmp_test.ts
+++ b/test/cmp_test.ts
@@ -624,10 +624,10 @@ describe("cmp.js", () => {
     });
 
     describe("Reverse", () => {
-        function arbReverse<A>(
-            arbVal: fc.Arbitrary<A>,
-        ): fc.Arbitrary<Reverse<A>> {
-            return arbVal.map((x) => new Reverse(x));
+        function arbReverse<T>(
+            arbVal: fc.Arbitrary<T>,
+        ): fc.Arbitrary<Reverse<T>> {
+            return arbVal.map((val) => new Reverse(val));
         }
 
         describe("#[Eq.eq]", () => {

--- a/test/either_test.ts
+++ b/test/either_test.ts
@@ -77,7 +77,7 @@ describe("either.js", () => {
 
         describe("goFn", () => {
             it("accesses the parameters of the generator function", () => {
-                const f = Either.goFn(function* <A>(w: A) {
+                const f = Either.goFn(function* <T>(w: T) {
                     const x = yield* Either.right<2, 1>(2);
                     const [y, z] = yield* Either.right<[2, 4], 3>([x, 4]);
                     return tuple(w, x, y, z);
@@ -174,7 +174,7 @@ describe("either.js", () => {
 
         describe("goAsyncFn", () => {
             it("accesses the parameters of the async generator function", async () => {
-                const f = Either.goAsyncFn(async function* <A>(w: A) {
+                const f = Either.goAsyncFn(async function* <T>(w: T) {
                     const x = yield* await Promise.resolve(
                         Either.right<2, 1>(2),
                     );

--- a/test/eval_test.ts
+++ b/test/eval_test.ts
@@ -69,7 +69,7 @@ describe("eval.js", () => {
 
         describe("goFn", () => {
             it("accesses the parameters of the generator function", () => {
-                const f = Eval.goFn(function* <A>(w: A) {
+                const f = Eval.goFn(function* <T>(w: T) {
                     const x = yield* Eval.now<1>(1);
                     const [y, z] = yield* Eval.now(tuple<[1, 2]>(x, 2));
                     return tuple(w, x, y, z);
@@ -132,27 +132,27 @@ describe("eval.js", () => {
             });
 
             it("implements a lawful semigroup", () => {
-                class RunEval<out A> {
-                    constructor(readonly val: Eval<A>) {}
+                class RunEval<out T> {
+                    constructor(readonly val: Eval<T>) {}
 
-                    [Eq.eq]<A extends Eq<A>>(
-                        this: RunEval<A>,
-                        that: RunEval<A>,
+                    [Eq.eq]<T extends Eq<T>>(
+                        this: RunEval<T>,
+                        that: RunEval<T>,
                     ): boolean {
                         return eq(this.val.run(), that.val.run());
                     }
 
-                    [Semigroup.cmb]<A extends Semigroup<A>>(
-                        this: RunEval<A>,
-                        that: RunEval<A>,
-                    ): RunEval<A> {
+                    [Semigroup.cmb]<T extends Semigroup<T>>(
+                        this: RunEval<T>,
+                        that: RunEval<T>,
+                    ): RunEval<T> {
                         return new RunEval(cmb(this.val, that.val));
                     }
                 }
 
-                function arbRunEval<A>(
-                    arb: fc.Arbitrary<A>,
-                ): fc.Arbitrary<RunEval<A>> {
+                function arbRunEval<T>(
+                    arb: fc.Arbitrary<T>,
+                ): fc.Arbitrary<RunEval<T>> {
                     return arb.chain((x) =>
                         fc
                             .oneof(

--- a/test/fn_test.ts
+++ b/test/fn_test.ts
@@ -44,8 +44,8 @@ describe("fn.js", () => {
 
     describe("wrapCtor", () => {
         it("adapts the constructor into a callable function", () => {
-            class Box<A> {
-                constructor(readonly val: A) {}
+            class Box<T> {
+                constructor(readonly val: T) {}
             }
             const f = wrapCtor(Box);
             const box = f<1>(1);

--- a/test/ior_test.ts
+++ b/test/ior_test.ts
@@ -147,7 +147,7 @@ describe("ior.js", () => {
 
         describe("goFn", () => {
             it("accesses the parameters of the generator function", () => {
-                const f = Ior.goFn(function* <A>(w: A) {
+                const f = Ior.goFn(function* <T>(w: T) {
                     const x = yield* Ior.both<Str, 2>(new Str("a"), 2);
                     const [y, z] = yield* Ior.both(
                         new Str("b"),
@@ -309,7 +309,7 @@ describe("ior.js", () => {
 
         describe("goAsyncFn", () => {
             it("accesses the parameters of the async generator function", async () => {
-                const f = Ior.goAsyncFn(async function* <A>(w: A) {
+                const f = Ior.goAsyncFn(async function* <T>(w: T) {
                     const x = yield* await Promise.resolve(
                         Ior.both<Str, 2>(new Str("a"), 2),
                     );

--- a/test/maybe_test.ts
+++ b/test/maybe_test.ts
@@ -14,13 +14,13 @@ import {
     tuple,
 } from "./util.js";
 
-function nothing<A>(): Maybe<A> {
+function nothing<T>(): Maybe<T> {
     return Maybe.nothing;
 }
 
 describe("maybe.js", () => {
     describe("Maybe", () => {
-        function arbMaybe<A>(arbVal: fc.Arbitrary<A>): fc.Arbitrary<Maybe<A>> {
+        function arbMaybe<T>(arbVal: fc.Arbitrary<T>): fc.Arbitrary<Maybe<T>> {
             return fc.oneof(fc.constant(Maybe.nothing), arbVal.map(Maybe.just));
         }
 
@@ -111,7 +111,7 @@ describe("maybe.js", () => {
 
         describe("goFn", () => {
             it("accesses the parameters of the generator function", () => {
-                const f = Maybe.goFn(function* <A>(w: A) {
+                const f = Maybe.goFn(function* <T>(w: T) {
                     const x = yield* Maybe.just<1>(1);
                     const [y, z] = yield* Maybe.just<[1, 2]>([x, 2]);
                     return tuple(w, x, y, z);
@@ -202,7 +202,7 @@ describe("maybe.js", () => {
 
         describe("goAsyncFn", () => {
             it("accesses the parameters of the async generator function", async () => {
-                const f = Maybe.goAsyncFn(async function* <A>(w: A) {
+                const f = Maybe.goAsyncFn(async function* <T>(w: T) {
                     const x = yield* await Promise.resolve(Maybe.just<1>(1));
                     const [y, z] = yield* await Promise.resolve(
                         Maybe.just<[1, 2]>([x, 2]),

--- a/test/util.ts
+++ b/test/util.ts
@@ -28,18 +28,18 @@ export class Str implements Semigroup<Str> {
 }
 
 export function arbNum(): fc.Arbitrary<Num> {
-    return fc.float({ noNaN: true }).map((x) => new Num(x));
+    return fc.float({ noNaN: true }).map((val) => new Num(val));
 }
 
 export function arbStr(): fc.Arbitrary<Str> {
-    return fc.string().map((x) => new Str(x));
+    return fc.string().map((val) => new Str(val));
 }
 
-export function tuple<T extends unknown[]>(...xs: T): T {
-    return xs;
+export function tuple<TArgs extends unknown[]>(...args: TArgs): TArgs {
+    return args;
 }
 
-export function expectLawfulEq<A extends Eq<A>>(arb: fc.Arbitrary<A>): void {
+export function expectLawfulEq<T extends Eq<T>>(arb: fc.Arbitrary<T>): void {
     fc.assert(
         fc.property(arb, (x) => {
             expect(eq(x, x), "reflexivity").to.be.true;
@@ -61,7 +61,7 @@ export function expectLawfulEq<A extends Eq<A>>(arb: fc.Arbitrary<A>): void {
     );
 }
 
-export function expectLawfulOrd<A extends Ord<A>>(arb: fc.Arbitrary<A>): void {
+export function expectLawfulOrd<T extends Ord<T>>(arb: fc.Arbitrary<T>): void {
     fc.assert(
         fc.property(arb, (x) => {
             expect(le(x, x), "reflexivity").to.be.true;
@@ -78,7 +78,7 @@ export function expectLawfulOrd<A extends Ord<A>>(arb: fc.Arbitrary<A>): void {
         fc.property(arb, arb, arb, (x, y, z) => {
             const [x1, y1, z1] = [x, y, z].sort((a, b) =>
                 cmp(a, b).toNumber(),
-            ) as [A, A, A];
+            ) as [T, T, T];
             expect(le(x1, y1) && le(y1, z1) && le(x1, z1), "transitivity").to.be
                 .true;
         }),
@@ -91,8 +91,8 @@ export function expectLawfulOrd<A extends Ord<A>>(arb: fc.Arbitrary<A>): void {
     );
 }
 
-export function expectLawfulSemigroup<A extends Semigroup<A> & Eq<A>>(
-    arb: fc.Arbitrary<A>,
+export function expectLawfulSemigroup<T extends Semigroup<T> & Eq<T>>(
+    arb: fc.Arbitrary<T>,
 ): void {
     fc.assert(
         fc.property(arb, arb, arb, (x, y, z) => {

--- a/test/validation_test.ts
+++ b/test/validation_test.ts
@@ -16,10 +16,10 @@ import {
 
 describe("validation.js", () => {
     describe("Validation", () => {
-        function arbValidation<E, A>(
+        function arbValidation<E, T>(
             arbErr: fc.Arbitrary<E>,
-            arbOk: fc.Arbitrary<A>,
-        ): fc.Arbitrary<Validation<E, A>> {
+            arbOk: fc.Arbitrary<T>,
+        ): fc.Arbitrary<Validation<E, T>> {
             return fc.oneof(
                 arbErr.map(Validation.err),
                 arbOk.map(Validation.ok),


### PR DESCRIPTION
- Prefer `T` as the default generic parameter for single-parameter types
- Prefer `A` and `B` as the default generic parameters for two-parameter types
- Prefer `TArgs` for describing spread function arguments
- Prefer `TYield` and `TReturn` for describing `yield` and `return` parameters for generator comprehensions
- Prefer more specific names for types with constraints (e.g. using `extends`), except for when the types extend `Eq`, `Ord`, `Semigroup`, or related interfaces
