### PR TITLE
Fix broken Markdown links in the documentation

### DIFF
--- a/src/cmb.ts
+++ b/src/cmb.ts
@@ -44,6 +44,8 @@
  * Sometimes it is necessary to work with arbitrary semigroups. To require that
  * a generic type `T` implements `Semigroup`, we write `T extends Semigroup<T>`.
  *
+ * [semigroups]: https://mathworld.wolfram.com/Semigroup.html
+ *
  * @example Working with generic semigroups
  *
  * Consider a program that combines an arbitrary semigroup with itself a finite
@@ -65,13 +67,13 @@
  * }
  * ```
  *
- * [semigroups]: https://mathworld.wolfram.com/Semigroup.html
- *
  * @module
  */
 
 /**
  * An interface that provides evidence of a [semigroup].
+ *
+ * [semigroup]: https://mathworld.wolfram.com/Semigroup.html
  *
  * @remarks
  *
@@ -138,6 +140,12 @@
  * The concrete implementation logic is similar to writing a method body for a
  * class or object, and the same practices apply when requiring generic type
  * parameters to implement `Semigroup`.
+ *
+ * [associative property]: https://mathworld.wolfram.com/Associative.html
+ * [structural subtyping]:
+ *     https://www.typescriptlang.org/docs/handbook/type-compatibility.html#site-content
+ * [augmentation]:
+ *     https://www.typescriptlang.org/docs/handbook/declaration-merging.html#module-augmentation
  *
  * @example Non-generic implementation
  *
@@ -270,13 +278,6 @@
  *     return new Pair(cmb(this.fst, that.fst), cmb(this.snd, that.snd));
  * };
  * ```
- *
- * [semigroup]: https://mathworld.wolfram.com/Semigroup.html
- * [associative property]: https://mathworld.wolfram.com/Associative.html
- * [structural subtyping]:
- *     https://www.typescriptlang.org/docs/handbook/type-compatibility.html#site-content
- * [augmentation]:
- *     https://www.typescriptlang.org/docs/handbook/declaration-merging.html#module-augmentation
  */
 export interface Semigroup<in out T> {
     /**

--- a/src/cmp.ts
+++ b/src/cmp.ts
@@ -145,6 +145,11 @@
  * total orders. To require that a generic type `T` implements `Eq` or `Ord`, we
  * write `T extends Eq<T>` or `T extends Ord<T>`, respectively.
  *
+ * [equivalence relations]:
+ *     https://mathworld.wolfram.com/EquivalenceRelation.html
+ * [total orders]: https://mathworld.wolfram.com/TotalOrder.html
+ * [lexicographically]: https://mathworld.wolfram.com/LexicographicOrder.html
+ *
  * @example Working with generic equivalence relations
  *
  * Consider a program that finds all `Eq` values in an array that occur only
@@ -173,11 +178,6 @@
  * }
  * ```
  *
- * [equivalence relations]:
- *     https://mathworld.wolfram.com/EquivalenceRelation.html
- * [total orders]: https://mathworld.wolfram.com/TotalOrder.html
- * [lexicographically]: https://mathworld.wolfram.com/LexicographicOrder.html
- *
  * @module
  */
 
@@ -185,6 +185,9 @@ import { Semigroup } from "./cmb.js";
 
 /**
  * An interface that provides evidence of an [equivalence relation].
+ *
+ * [equivalence relation]:
+ *     https://mathworld.wolfram.com/EquivalenceRelation.html
  *
  * @remarks
  *
@@ -251,6 +254,11 @@ import { Semigroup } from "./cmb.js";
  * The concrete implementation logic is similar to writing a method body for a
  * class or object, and the same practices apply for requiring generic
  * parameters to implement `Eq`.
+ *
+ * [structural subtyping]:
+ *     https://www.typescriptlang.org/docs/handbook/type-compatibility.html#site-content
+ * [augmentation]:
+ *     https://www.typescriptlang.org/docs/handbook/declaration-merging.html#module-augmentation
  *
  * @example Non-generic implementation
  *
@@ -393,13 +401,6 @@ import { Semigroup } from "./cmb.js";
  *     return ieq(this, that);
  * };
  * ```
- *
- * [equivalence relation]:
- *     https://mathworld.wolfram.com/EquivalenceRelation.html
- * [structural subtyping]:
- *     https://www.typescriptlang.org/docs/handbook/type-compatibility.html#site-content
- * [augmentation]:
- *     https://www.typescriptlang.org/docs/handbook/declaration-merging.html#module-augmentation
  */
 export interface Eq<in T> {
     /**
@@ -494,6 +495,8 @@ export function ieq<T extends Eq<T>>(
 /**
  * An interface that provides evidence of a [total order].
  *
+ * [total order]: https://mathworld.wolfram.com/TotalOrder.html
+ *
  * @remarks
  *
  * ## Properties
@@ -569,6 +572,11 @@ export function ieq<T extends Eq<T>>(
  * The concrete implementation logic is similar to writing a method body for a
  * class or object, and the same practices apply for requiring generic
  * parameters to implement `Ord`.
+ *
+ * [structural subtyping]:
+ *     https://www.typescriptlang.org/docs/handbook/type-compatibility.html#site-content
+ * [augmentation]:
+ *     https://www.typescriptlang.org/docs/handbook/declaration-merging.html#module-augmentation
  *
  * @example Non-generic implementation
  *
@@ -658,7 +666,7 @@ export function ieq<T extends Eq<T>>(
  *         // An exercise for the reader...
  *     }
  *
- *     [Ord.cmp]<T extends Ord<T>>(this: Arr<T>, that, Arr<T>): Ordering {
+ *     [Ord.cmp]<T extends Ord<T>>(this: Arr<T>, that: Arr<T>): Ordering {
  *         return icmp(this.val, that.val);
  *     }
  * }
@@ -755,12 +763,6 @@ export function ieq<T extends Eq<T>>(
  *     return icmp(this, that);
  * };
  * ```
- *
- * [total order]: https://mathworld.wolfram.com/TotalOrder.html
- * [structural subtyping]:
- *     https://www.typescriptlang.org/docs/handbook/type-compatibility.html#site-content
- * [augmentation]:
- *     https://www.typescriptlang.org/docs/handbook/declaration-merging.html#module-augmentation
  */
 export interface Ord<in T> extends Eq<T> {
     /**


### PR DESCRIPTION
Markdown link references don't seem to work accross TSDoc block scopes (e.g. `@remarks` and `@example`). To work around this, place all links in the same block as their references.