### PR TITLE
Refactor generator comprehensions

### DIFF
--- a/src/_test/utils.ts
+++ b/src/_test/utils.ts
@@ -51,10 +51,6 @@ export function arbStr(): fc.Arbitrary<Str> {
 	return fc.string().map((val) => new Str(val));
 }
 
-export function tuple<TArgs extends unknown[]>(...args: TArgs): TArgs {
-	return args;
-}
-
 export function expectLawfulEq<T extends Eq<T>>(arb: fc.Arbitrary<T>): void {
 	fc.assert(
 		fc.property(arb, (x) => {

--- a/src/either.test.ts
+++ b/src/either.test.ts
@@ -22,7 +22,6 @@ import {
 	expectLawfulEq,
 	expectLawfulOrd,
 	expectLawfulSemigroup,
-	tuple,
 } from "./_test/utils.js";
 import { cmb } from "./cmb.js";
 import { Ordering, cmp, eq } from "./cmp.js";
@@ -72,7 +71,7 @@ describe("Either", () => {
 			function* f(): Either.Go<1 | [2, 3], [2, 4]> {
 				const x = yield* Either.right<2, 1>(2);
 				const y = yield* Either.left<[2, 3], 4>([x, 3]);
-				return tuple(x, y);
+				return [x, y];
 			}
 			const either = Either.go(f());
 			expect(either).to.deep.equal(Either.left([2, 3]));
@@ -82,7 +81,7 @@ describe("Either", () => {
 			function* f(): Either.Go<1 | 3, [2, 2, 4]> {
 				const x = yield* Either.right<2, 1>(2);
 				const [y, z] = yield* Either.right<[2, 4], 3>([x, 4]);
-				return tuple(x, y, z);
+				return [x, y, z];
 			}
 			const either = Either.go(f());
 			expect(either).to.deep.equal(Either.right([2, 2, 4]));
@@ -154,7 +153,10 @@ describe("Either", () => {
 
 	describe("lift", () => {
 		it("lifts the function into the context of Either", () => {
-			const either = Either.lift(tuple<[2, 4]>)(
+			function f<A, B>(lhs: A, rhs: B): [A, B] {
+				return [lhs, rhs];
+			}
+			const either = Either.lift(f<2, 4>)(
 				Either.right<2, 1>(2),
 				Either.right<4, 3>(4),
 			);
@@ -169,7 +171,7 @@ describe("Either", () => {
 				const y = yield* await Promise.resolve(
 					Either.left<[2, 3], 4>([x, 3]),
 				);
-				return tuple(x, y);
+				return [x, y];
 			}
 			const either = await Either.goAsync(f());
 			expect(either).to.deep.equal(Either.left([2, 3]));
@@ -181,7 +183,7 @@ describe("Either", () => {
 				const [y, z] = yield* await Promise.resolve(
 					Either.right<[2, 4], 3>([x, 4]),
 				);
-				return tuple(x, y, z);
+				return [x, y, z];
 			}
 			const either = await Either.goAsync(f());
 			expect(either).to.deep.equal(Either.right([2, 2, 4]));
@@ -195,7 +197,7 @@ describe("Either", () => {
 				const [y, z] = yield* await Promise.resolve(
 					Either.right<Promise<[2, 4]>, 3>(Promise.resolve([x, 4])),
 				);
-				return Promise.resolve(tuple(x, y, z));
+				return Promise.resolve([x, y, z]);
 			}
 			const either = await Either.goAsync(f());
 			expect(either).to.deep.equal(Either.right([2, 2, 4]));
@@ -416,7 +418,7 @@ describe("Either", () => {
 		it("applies the function to the successes if both variants are Right", () => {
 			const either = Either.right<2, 1>(2).zipWith(
 				Either.right<4, 3>(4),
-				tuple,
+				(lhs, rhs): [2, 4] => [lhs, rhs],
 			);
 			expect(either).to.deep.equal(Either.right([2, 4]));
 		});

--- a/src/either.test.ts
+++ b/src/either.test.ts
@@ -69,26 +69,28 @@ describe("Either", () => {
 
 	describe("go", () => {
 		it("short-cicruits on the first yielded Left", () => {
-			const either = Either.go(function* () {
+			function* f(): Either.Go<1 | [2, 3], [2, 4]> {
 				const x = yield* Either.right<2, 1>(2);
 				const y = yield* Either.left<[2, 3], 4>([x, 3]);
 				return tuple(x, y);
-			});
+			}
+			const either = Either.go(f());
 			expect(either).to.deep.equal(Either.left([2, 3]));
 		});
 
 		it("completes if all yielded values are Right", () => {
-			const either = Either.go(function* () {
+			function* f(): Either.Go<1 | 3, [2, 2, 4]> {
 				const x = yield* Either.right<2, 1>(2);
 				const [y, z] = yield* Either.right<[2, 4], 3>([x, 4]);
 				return tuple(x, y, z);
-			});
+			}
+			const either = Either.go(f());
 			expect(either).to.deep.equal(Either.right([2, 2, 4]));
 		});
 
 		it("executes the finally block if a Left is yielded in the try block", () => {
 			const logs: string[] = [];
-			const either = Either.go(function* () {
+			function* f(): Either.Go<1, number[]> {
 				try {
 					const results = [];
 					const x = yield* Either.left<1, 2>(1);
@@ -97,13 +99,14 @@ describe("Either", () => {
 				} finally {
 					logs.push("finally");
 				}
-			});
+			}
+			const either = Either.go(f());
 			expect(either).to.deep.equal(Either.left(1));
 			expect(logs).to.deep.equal(["finally"]);
 		});
 
 		it("keeps the most recent yielded Left when using try and finally blocks", () => {
-			const either = Either.go(function* () {
+			function* f(): Either.Go<1 | 3, number[]> {
 				try {
 					const results = [];
 					const x = yield* Either.left<1, 2>(1);
@@ -112,7 +115,8 @@ describe("Either", () => {
 				} finally {
 					yield* Either.left<3, 4>(3);
 				}
-			});
+			}
+			const either = Either.go(f());
 			expect(either).to.deep.equal(Either.left(3));
 		});
 	});
@@ -160,29 +164,31 @@ describe("Either", () => {
 
 	describe("goAsync", () => {
 		it("short-circuits on the first yielded Left", async () => {
-			const either = await Either.goAsync(async function* () {
+			async function* f(): Either.GoAsync<1 | [2, 3], [2, 4]> {
 				const x = yield* await Promise.resolve(Either.right<2, 1>(2));
 				const y = yield* await Promise.resolve(
 					Either.left<[2, 3], 4>([x, 3]),
 				);
 				return tuple(x, y);
-			});
+			}
+			const either = await Either.goAsync(f());
 			expect(either).to.deep.equal(Either.left([2, 3]));
 		});
 
 		it("completes and returns if all yielded values are Right", async () => {
-			const either = await Either.goAsync(async function* () {
+			async function* f(): Either.GoAsync<1 | 3, [2, 2, 4]> {
 				const x = yield* await Promise.resolve(Either.right<2, 1>(2));
 				const [y, z] = yield* await Promise.resolve(
 					Either.right<[2, 4], 3>([x, 4]),
 				);
 				return tuple(x, y, z);
-			});
+			}
+			const either = await Either.goAsync(f());
 			expect(either).to.deep.equal(Either.right([2, 2, 4]));
 		});
 
 		it("unwraps Promises in Right variants and in return", async () => {
-			const either = await Either.goAsync(async function* () {
+			async function* f(): Either.GoAsync<1 | 3, [2, 2, 4]> {
 				const x = yield* await Promise.resolve(
 					Either.right<Promise<2>, 1>(Promise.resolve(2)),
 				);
@@ -190,13 +196,14 @@ describe("Either", () => {
 					Either.right<Promise<[2, 4]>, 3>(Promise.resolve([x, 4])),
 				);
 				return Promise.resolve(tuple(x, y, z));
-			});
+			}
+			const either = await Either.goAsync(f());
 			expect(either).to.deep.equal(Either.right([2, 2, 4]));
 		});
 
 		it("executes the finally block if a Left is yielded in the try block", async () => {
 			const logs: string[] = [];
-			const either = await Either.goAsync(async function* () {
+			async function* f(): Either.GoAsync<1, number[]> {
 				try {
 					const results = [];
 					const x = yield* await Promise.resolve(
@@ -207,13 +214,14 @@ describe("Either", () => {
 				} finally {
 					logs.push("finally");
 				}
-			});
+			}
+			const either = await Either.goAsync(f());
 			expect(either).to.deep.equal(Either.left(1));
 			expect(logs).to.deep.equal(["finally"]);
 		});
 
 		it("keeps the most recent yielded Left when using try and finally blocks", async () => {
-			const either = await Either.goAsync(async function* () {
+			async function* f(): Either.GoAsync<1 | 3, number[]> {
 				try {
 					const results = [];
 					const x = yield* await Promise.resolve(
@@ -224,7 +232,8 @@ describe("Either", () => {
 				} finally {
 					yield* await Promise.resolve(Either.left<3, 4>(3));
 				}
-			});
+			}
+			const either = await Either.goAsync(f());
 			expect(either).to.deep.equal(Either.left(3));
 		});
 	});

--- a/src/either.test.ts
+++ b/src/either.test.ts
@@ -414,6 +414,24 @@ describe("Either", () => {
 		});
 	});
 
+	describe("#goMap", () => {
+		it("does not apply the continuation if the variant is Left", () => {
+			const either = Either.left<1, 2>(1).goMap(function* (x) {
+				const y = yield* Either.right<4, 3>(4);
+				return [x, y] as [2, 4];
+			});
+			expect(either).to.deep.equal(Either.left(1));
+		});
+
+		it("applies the continuation to the success if the variant is Right", () => {
+			const either = Either.right<2, 1>(2).goMap(function* (x) {
+				const y = yield* Either.right<4, 3>(4);
+				return [x, y] as [2, 4];
+			});
+			expect(either).to.deep.equal(Either.right([2, 4]));
+		});
+	});
+
 	describe("#zipWith", () => {
 		it("applies the function to the successes if both variants are Right", () => {
 			const either = Either.right<2, 1>(2).zipWith(

--- a/src/either.test.ts
+++ b/src/either.test.ts
@@ -117,18 +117,6 @@ describe("Either", () => {
 		});
 	});
 
-	describe("goFn", () => {
-		it("accesses the parameters of the generator function", () => {
-			const f = Either.goFn(function* <T>(w: T) {
-				const x = yield* Either.right<2, 1>(2);
-				const [y, z] = yield* Either.right<[2, 4], 3>([x, 4]);
-				return tuple(w, x, y, z);
-			});
-			const either = f<0>(0);
-			expect(either).to.deep.equal(Either.right([0, 2, 2, 4]));
-		});
-	});
-
 	describe("reduce", () => {
 		it("reduces the finite iterable from left to right in the context of Either", () => {
 			const either = Either.reduce(
@@ -238,20 +226,6 @@ describe("Either", () => {
 				}
 			});
 			expect(either).to.deep.equal(Either.left(3));
-		});
-	});
-
-	describe("goAsyncFn", () => {
-		it("accesses the parameters of the async generator function", async () => {
-			const f = Either.goAsyncFn(async function* <T>(w: T) {
-				const x = yield* await Promise.resolve(Either.right<2, 1>(2));
-				const [y, z] = yield* await Promise.resolve(
-					Either.right<[2, 4], 3>([x, 4]),
-				);
-				return tuple(w, x, y, z);
-			});
-			const either = await f<0>(0);
-			expect(either).to.deep.equal(Either.right([0, 2, 2, 4]));
 		});
 	});
 

--- a/src/either.ts
+++ b/src/either.ts
@@ -804,7 +804,11 @@ export namespace Either {
 	/**
 	 *
 	 */
-	export type Go<E, TReturn> = Generator<Either<E, any>, TReturn, undefined>;
+	export type Go<E, TReturn> = Generator<
+		Either<E, unknown>,
+		TReturn,
+		unknown
+	>;
 
 	/**
 	 *
@@ -812,7 +816,7 @@ export namespace Either {
 	export type GoAsync<E, TReturn> = AsyncGenerator<
 		Either<E, any>,
 		TReturn,
-		undefined
+		unknown
 	>;
 
 	/**

--- a/src/either.ts
+++ b/src/either.ts
@@ -268,19 +268,6 @@
  * // input "0x2A": 42
  * ```
  *
- * We can refactor the `parseEvenInt` function to use a generator comprehension
- * instead:
- *
- * ```ts
- * function parseEvenInt(input: string): Either<string, number> {
- *     return Either.go(function* () {
- *         const n = yield* parseInt(input);
- *         const even = yield* guardEven(n);
- *         return even;
- *     });
- * }
- * ```
- *
  * Suppose we want to parse an array of inputs and collect the successful
  * results, or fail on the first parse error. We may write the following:
  *
@@ -303,37 +290,8 @@
  * // inputs ["+42","0x2A"]: [42,42]
  * ```
  *
- * Perhaps we want to collect only distinct even numbers using a `Set`:
- *
- * ```ts
- * function parseEvenIntsUniq(inputs: string[]): Either<string, Set<number>> {
- *     return Either.go(function* () {
- *         const results = new Set<number>();
- *         for (const input of inputs) {
- *             results.add(yield* parseEvenInt(input));
- *         }
- *         return results;
- *     });
- * }
- *
- * [
- *     ["a", "-4"],
- *     ["2", "-7"],
- *     ["+42", "0x2A"],
- * ].forEach((inputs) => {
- *     const result = JSON.stringify(
- *         parseEvenIntsUniq(inputs).map(Array.from).val,
- *     );
- *     console.log(`inputs ${JSON.stringify(inputs)}: ${result}`);
- * });
- *
- * // inputs ["a","-4"]: "cannot parse 'a' as int"
- * // inputs ["2","-7"]: "-7 is not even"
- * // inputs ["+42","0x2A"]: [42]
- * ```
- *
- * Or, perhaps we want to associate the original input strings with our
- * successful parses:
+ * Perhaps we want to associate the original input strings with our successful
+ * parses:
  *
  * ```ts
  * function parseEvenIntsKeyed(

--- a/src/either.ts
+++ b/src/either.ts
@@ -507,24 +507,6 @@ export namespace Either {
 	}
 
 	/**
-	 * Construct a function that returns an `Either` using a generator
-	 * comprehension.
-	 *
-	 * @remarks
-	 *
-	 * This is the higher-order function variant of `go`.
-	 */
-	export function goFn<
-		TArgs extends unknown[],
-		TYield extends Either<any, any>,
-		TReturn,
-	>(
-		f: (...args: TArgs) => Generator<TYield, TReturn, unknown>,
-	): (...args: TArgs) => Either<LeftT<TYield>, TReturn> {
-		return (...args) => step(f(...args));
-	}
-
-	/**
 	 * Reduce a finite iterable from left to right in the context of `Either`.
 	 *
 	 * @remarks
@@ -684,24 +666,6 @@ export namespace Either {
 		f: () => AsyncGenerator<TYield, TReturn, unknown>,
 	): Promise<Either<LeftT<TYield>, TReturn>> {
 		return stepAsync(f());
-	}
-
-	/**
-	 * Construct a function that returns a `Promise` that fulfills with an
-	 * `Either` using an async generator comprehension.
-	 *
-	 * @remarks
-	 *
-	 * This is the higher-order function variant of `goAsync`.
-	 */
-	export function goAsyncFn<
-		TArgs extends unknown[],
-		TYield extends Either<any, any>,
-		TReturn,
-	>(
-		f: (...args: TArgs) => AsyncGenerator<TYield, TReturn, unknown>,
-	): (...args: TArgs) => Promise<Either<LeftT<TYield>, TReturn>> {
-		return (...args) => stepAsync(f(...args));
 	}
 
 	/**

--- a/src/either.ts
+++ b/src/either.ts
@@ -165,7 +165,7 @@
  * return type. An async generator function that returns an `Either.GoAsync<E,
  * T>` may `yield*` zero or more `Either<E, any>` values and must return a
  * result of type `T`. `PromiseLike` values that resolve with `Either` should
- * be awaited before yielding. Async comprehensions may also `yieid*` other
+ * be awaited before yielding. Async comprehensions may also `yield*` other
  * `Either.Go` and `Either.GoAsync` generators directly.
  *
  * Each `yield*` expression may bind a variable of the success value type of the

--- a/src/either.ts
+++ b/src/either.ts
@@ -171,7 +171,7 @@
  * Each `yield*` expression may bind a variable of the success value type of the
  * yielded `Either`. Comprehensions should always use `yield*` instead of
  * `yield`. Using `yield*` allows TypeScript to accurately infer the success
- * value type of each yielded `Either` when binding the value of a `yield*`
+ * value type of the yielded `Either` when binding the value of each `yield*`
  * expression.
  *
  * ### Evaluating comprehensions

--- a/src/either.ts
+++ b/src/either.ts
@@ -434,17 +434,18 @@ export namespace Either {
 	export function go<E, TReturn>(gen: Go<E, TReturn>): Either<E, TReturn> {
 		let nxt = gen.next();
 		let err: any;
+		let isHalted = false;
 		while (!nxt.done) {
 			const either = nxt.value;
 			if (either.isRight()) {
 				nxt = gen.next(either.val);
 			} else {
 				err = either.val;
-				nxt = gen.return(halt as any);
+				isHalted = true;
+				nxt = gen.return(undefined as any);
 			}
 		}
-		const result = nxt.value;
-		return result === halt ? left(err) : right(result);
+		return isHalted ? left(err) : right(nxt.value);
 	}
 
 	/**
@@ -565,17 +566,18 @@ export namespace Either {
 	): Promise<Either<E, TReturn>> {
 		let nxt = await gen.next();
 		let err: any;
+		let isHalted = false;
 		while (!nxt.done) {
 			const either = nxt.value;
 			if (either.isRight()) {
 				nxt = await gen.next(either.val);
 			} else {
 				err = either.val;
-				nxt = await gen.return(halt as any);
+				isHalted = true;
+				nxt = await gen.return(undefined as any);
 			}
 		}
-		const result = nxt.value;
-		return result === halt ? left(err) : right(result);
+		return isHalted ? left(err) : right(nxt.value);
 	}
 
 	/**
@@ -830,9 +832,4 @@ export namespace Either {
 	]
 		? B
 		: never;
-
-	// A unique symbol used by the `Either` generator comprehension
-	// implementation to signal the underlying generator to return early. This
-	// ensures `try...finally` blocks can execute.
-	const halt = Symbol();
 }

--- a/src/either.ts
+++ b/src/either.ts
@@ -387,7 +387,7 @@ export namespace Either {
 	}
 
 	/**
-	 *
+	 * Interpret an `Either.Go` generator to return an `Either`.
 	 */
 	export function go<E, TReturn>(gen: Go<E, TReturn>): Either<E, TReturn> {
 		let nxt = gen.next();
@@ -519,6 +519,10 @@ export namespace Either {
 			collect(eithers).map((args) => f(...(args as TArgs)));
 	}
 
+	/**
+	 * Interpret an `Either.GoAsync` async generator to return a `Promise` that
+	 * resolves with an `Either`.
+	 */
 	export async function goAsync<E, TReturn>(
 		gen: GoAsync<E, TReturn>,
 	): Promise<Either<E, TReturn>> {
@@ -635,7 +639,9 @@ export namespace Either {
 		}
 
 		/**
-		 *
+		 * If this `Either`, suceeds, apply a generator comprehension function
+		 * to its success and interpret the `Either.Go` generator to return
+		 * another `Either`; otherwise, return this `Either` as is.
 		 */
 		goMap<E, T, E1, T1>(
 			this: Either<E, T>,
@@ -727,13 +733,12 @@ export namespace Either {
 		}
 
 		/**
-		 * Defining iterable behavior for `Either` allows TypeScript to infer
-		 * right-sided value types when yielding `Either` values in generator
-		 * comprehensions using `yield*`.
-		 *
-		 * @hidden
+		 * Return an `Either.Go` generator that yields this `Either` and returns
+		 * its right-hand value if one is present. This allows `Either` values
+		 * to be yielded directly in `Either` generator comprehensions using
+		 * `yield*`.
 		 */
-		*[Symbol.iterator](): Iterator<Either<A, never>, never, unknown> {
+		*[Symbol.iterator](): Generator<Either<A, never>, never, unknown> {
 			return (yield this) as never;
 		}
 	}
@@ -758,19 +763,18 @@ export namespace Either {
 		}
 
 		/**
-		 * Defining iterable behavior for `Either` allows TypeScript to infer
-		 * right-sided value types when yielding `Either` values in generator
-		 * comprehensions using `yield*`.
-		 *
-		 * @hidden
+		 * Return an `Either.Go` generator that yields this `Either` and returns
+		 * its right-hand value if one is present. This allows `Either` values
+		 * to be yielded directly in `Either` generator comprehensions using
+		 * `yield*`.
 		 */
-		*[Symbol.iterator](): Iterator<Either<never, B>, B, unknown> {
+		*[Symbol.iterator](): Generator<Either<never, B>, B, unknown> {
 			return (yield this) as B;
 		}
 	}
 
 	/**
-	 *
+	 * A generator that yields `Either` values and returns a result.
 	 */
 	export type Go<E, TReturn> = Generator<
 		Either<E, unknown>,
@@ -779,7 +783,7 @@ export namespace Either {
 	>;
 
 	/**
-	 *
+	 * An async generator that yields `Either` values and returns a result.
 	 */
 	export type GoAsync<E, TReturn> = AsyncGenerator<
 		Either<E, any>,

--- a/src/either.ts
+++ b/src/either.ts
@@ -677,6 +677,16 @@ export namespace Either {
 		}
 
 		/**
+		 *
+		 */
+		goMap<E, T, E1, T1>(
+			this: Either<E, T>,
+			f: (val: T) => Go<E1, T1>,
+		): Either<E | E1, T1> {
+			return this.flatMap((val) => go(f(val)));
+		}
+
+		/**
 		 * If this and that `Either` both succeed, apply a function to their
 		 * successes and succeed with the result; otherwise, return the first
 		 * failed `Either`.

--- a/src/either.ts
+++ b/src/either.ts
@@ -179,7 +179,7 @@
  * `Either.Go` and `Either.GoAsync` generators must be evaluated before
  * accessing their results.
  *
- * The `go` function evaluates an `Either.Go<E, T> generator to return an
+ * The `go` function evaluates an `Either.Go<E, T>` generator to return an
  * `Either<E, T>`. If any yielded `Either` fails, the generator halts and `go`
  * returns the failed `Either`; otherwise, when the generator returns, `go`
  * returns the result as a success.

--- a/src/eval.test.ts
+++ b/src/eval.test.ts
@@ -179,6 +179,17 @@ describe("Eval", () => {
 		});
 	});
 
+	describe("#goMap", () => {
+		it("applies the continuation to the outcome", () => {
+			const ev = Eval.now<1>(1).goMap(function* (x) {
+				const y = yield* Eval.now<2>(2);
+				return [x, y] as [1, 2];
+			});
+			const outcome = ev.run();
+			expect(outcome).to.deep.equal([1, 2]);
+		});
+	});
+
 	describe("#zipWith", () => {
 		it("applies the function to the outcomes", () => {
 			const ev = Eval.now<1>(1).zipWith(

--- a/src/eval.test.ts
+++ b/src/eval.test.ts
@@ -72,11 +72,12 @@ describe("Eval", () => {
 
 	describe("go", () => {
 		it("constructs an Eval using the generator comprehension", () => {
-			const ev = Eval.go(function* () {
+			function* f(): Eval.Go<[1, 1, 2]> {
 				const x = yield* Eval.now<1>(1);
 				const [y, z] = yield* Eval.now(tuple<[1, 2]>(x, 2));
 				return tuple(x, y, z);
-			});
+			}
+			const ev = Eval.go(f());
 			const outcome = ev.run();
 			expect(outcome).to.deep.equal([1, 1, 2]);
 		});

--- a/src/eval.test.ts
+++ b/src/eval.test.ts
@@ -82,19 +82,6 @@ describe("Eval", () => {
 		});
 	});
 
-	describe("goFn", () => {
-		it("accesses the parameters of the generator function", () => {
-			const f = Eval.goFn(function* <T>(w: T) {
-				const x = yield* Eval.now<1>(1);
-				const [y, z] = yield* Eval.now(tuple<[1, 2]>(x, 2));
-				return tuple(w, x, y, z);
-			});
-			const ev = f<0>(0);
-			const outcome = ev.run();
-			expect(outcome).to.deep.equal([0, 1, 1, 2]);
-		});
-	});
-
 	describe("reduce", () => {
 		it("reduces the finite iterable from left to right in the context of Eval", () => {
 			const ev = Eval.reduce(["x", "y"], (xs, x) => Eval.now(xs + x), "");

--- a/src/eval.ts
+++ b/src/eval.ts
@@ -77,17 +77,28 @@
  * function is applied to the outcome of one `Eval` to return another `Eval`.
  * Composition with `flatMap` is stack safe, even for recursive programs.
  *
- * ### Generator comprehensions
+ * ## Generator comprehenshions
  *
  * Generator comprehensions provide an imperative syntax for chaining together
- * computations that return `Eval`. Instead of `flatMap`, a generator is used
- * to apply functions to the the outcomes of `Eval` values.
+ * synchronous computations that return `Eval` values.
  *
- * The `go` static method evaluates a generator to return an `Eval`. Within the
- * generator, `Eval` values are yielded using the `yield*` keyword, allowing
- * their outcomes to be bound to specified variables. When the computation is
- * complete, the generator may return a final result and `go` returns the result
- * in an `Eval`.
+ * ### Writing comprehensions
+ *
+ * Comprehensions are written using `function*` declarations. Generator
+ * functions should use the `Eval.Go` type alias as a return type. A generator
+ * function that returns an `Eval.Go<T>` may `yield*` zero or more `Eval<any>`
+ * values and must return a result of type `T`. Comprehensions may also `yield*`
+ * other `Eval.Go` generators directly.
+ *
+ * Each `yield*` expression may bind a variable of the outcome value type of the
+ * yielded `Eval`. Comprehensions should always use `yield*` instead of `yield`.
+ * Using `yield*` allows TypeScript to accurately infer the outcome value type
+ * of each yielded `Eval` when binding the value of a `yield*` expression.
+ *
+ * ### Evaluating comprehensions
+ *
+ * `Eval.Go` generators must be evaluated before accessing their results. The
+ * `go` function evaluates an `Eval.Go<T> generator to return an `Eval<T>`.
  *
  * `Eval` is automatically deferred in its implementation of `go`. The body of
  * the provided generator does not execute until the `Eval` is evaluated using

--- a/src/eval.ts
+++ b/src/eval.ts
@@ -98,7 +98,7 @@
  * ### Evaluating comprehensions
  *
  * `Eval.Go` generators must be evaluated before accessing their results. The
- * `go` function evaluates an `Eval.Go<T> generator to return an `Eval<T>`.
+ * `go` function evaluates an `Eval.Go<T>` generator to return an `Eval<T>`.
  *
  * `Eval` is automatically deferred in its implementation of `go`. The body of
  * the provided generator does not execute until the `Eval` is evaluated using

--- a/src/eval.ts
+++ b/src/eval.ts
@@ -309,7 +309,7 @@ export class Eval<out T> {
 	}
 
 	/**
-	 * Interpret an `Eval.Go` generator to return an `Eval`.
+	 * Evaluate an `Eval.Go` generator to return an `Eval`.
 	 */
 	static go<TReturn>(gen: Eval.Go<TReturn>): Eval<TReturn> {
 		return Eval.defer(() => Eval.#step(gen, gen.next()));
@@ -451,7 +451,7 @@ export class Eval<out T> {
 
 	/**
 	 * Apply a generator comprehension function to the outcome of this `Eval`
-	 * and interpret the `Eval.Go` generator to return another `Eval`.
+	 * and evaluate the `Eval.Go` generator to return another `Eval`.
 	 */
 	goMap<T1>(f: (val: T) => Eval.Go<T1>): Eval<T1> {
 		return this.flatMap((val) => Eval.go(f(val)));

--- a/src/eval.ts
+++ b/src/eval.ts
@@ -93,7 +93,7 @@
  * Each `yield*` expression may bind a variable of the outcome value type of the
  * yielded `Eval`. Comprehensions should always use `yield*` instead of `yield`.
  * Using `yield*` allows TypeScript to accurately infer the outcome value type
- * of each yielded `Eval` when binding the value of a `yield*` expression.
+ * of the yielded `Eval` when binding the value of each `yield*` expression.
  *
  * ### Evaluating comprehensions
  *

--- a/src/eval.ts
+++ b/src/eval.ts
@@ -483,6 +483,13 @@ export class Eval<out T> {
 	}
 
 	/**
+	 *
+	 */
+	goMap<T1>(f: (val: T) => Eval.Go<T1>): Eval<T1> {
+		return this.flatMap((val) => Eval.go(f(val)));
+	}
+
+	/**
 	 * Apply a function to the outcomes of this and that `Eval` and return the
 	 * result in an `Eval`.
 	 */

--- a/src/eval.ts
+++ b/src/eval.ts
@@ -298,7 +298,7 @@ export class Eval<out T> {
 	}
 
 	/**
-	 *
+	 * Interpret an `Eval.Go` generator to return an `Eval`.
 	 */
 	static go<TReturn>(gen: Eval.Go<TReturn>): Eval<TReturn> {
 		return Eval.defer(() => Eval.#step(gen, gen.next()));
@@ -412,13 +412,11 @@ export class Eval<out T> {
 	}
 
 	/**
-	 * Defining iterable behavior for `Eval` allows TypeScript to infer outcome
-	 * types when yielding `Eval` values in generator comprehensions using
-	 * `yield*`.
-	 *
-	 * @hidden
+	 * Return an `Eval.Go` generator that yields this `Eval` and returns its
+	 * its outcome. This allows `Eval` values to be yielded directly in `Eval`
+	 * generator comprehensions using `yield*`.
 	 */
-	*[Symbol.iterator](): Iterator<Eval<T>, T, unknown> {
+	*[Symbol.iterator](): Generator<Eval<T>, T, unknown> {
 		return (yield this) as T;
 	}
 
@@ -441,7 +439,8 @@ export class Eval<out T> {
 	}
 
 	/**
-	 *
+	 * Apply a generator comprehension function to the outcome of this `Eval`
+	 * and interpret the `Eval.Go` generator to return another `Eval`.
 	 */
 	goMap<T1>(f: (val: T) => Eval.Go<T1>): Eval<T1> {
 		return this.flatMap((val) => Eval.go(f(val)));
@@ -528,7 +527,7 @@ export class Eval<out T> {
  */
 export namespace Eval {
 	/**
-	 *
+	 * A generator that yields `Eval` values and returns a result.
 	 */
 	export type Go<TReturn> = Generator<Eval<unknown>, TReturn, unknown>;
 

--- a/src/eval.ts
+++ b/src/eval.ts
@@ -189,28 +189,6 @@
  * // [1,2,3,4,5,6,7]
  * ```
  *
- * We can refactor the `foldTree` function to use a generator comprehension
- * instead:
- *
- * ```ts
- * function foldTree<T, TAcc>(
- *     tree: Tree<T>,
- *     ifEmpty: TAcc,
- *     foldBranch: (val: T, lhs: TAcc, rhs: TAcc) => TAcc
- * ): Eval<TAcc> {
- *     return Eval.go(function* () {
- *         if (tree.kind === "EMPTY") {
- *             return ifEmpty;
- *         }
- *         // Challenge for the reader: why is `defer` not needed here?
- *         // Hint: it pertains to the behavior of `go`.
- *         const lhs = yield* foldTree(tree.lst, ifEmpty, foldBranch);
- *         const rhs = yield* foldTree(tree.rst, ifEmpty, foldBranch);
- *         return foldBranch(tree.val, lhs, rhs);
- *     });
- * }
- * ```
- *
  * Suppose we wanted to traverse a tree in multiple ways and collect the results
  * of each traversal. We may write the following:
  *
@@ -267,26 +245,6 @@
  * console.log(JSON.stringify(traversalsKeyed(oneToSeven).run()));
  *
  * // {"in":[1,2,3,4,5,6,7],"pre":[4,2,1,3,6,5,7],"post":[1,3,2,5,7,6,4]}
- * ```
- *
- * Or, perhaps we want to return a `Map` instead:
- *
- * ```ts
- * function traversalsMap(tree: Tree<T>): Eval<Map<string, T[]>> {
- *     return Eval.go(function* () {
- *         const results = new Map<string, T[]>();
- *
- *         results.set("in", yield* inOrder(tree));
- *         results.set("pre", yield* preOrder(tree));
- *         results.set("post", yield* postOrder(tree));
- *
- *         return results;
- *     });
- * }
- *
- * console.log(JSON.stringify(traversalsMap(oneToSeven).map(Array.from).run()));
- *
- * // [["in",[1,2,3,4,5,6,7]],["pre",[4,2,1,3,6,5,7]],["post",[1,3,2,5,7,6,4]]]
  * ```
  *
  * @module

--- a/src/eval.ts
+++ b/src/eval.ts
@@ -389,24 +389,6 @@ export class Eval<out T> {
 	}
 
 	/**
-	 * Construct a function that returns an `Eval` using a generator
-	 * comprehension.
-	 *
-	 * @remarks
-	 *
-	 * This is the higher-order function variant of `go`.
-	 */
-	static goFn<TArgs extends unknown[], TReturn>(
-		f: (...args: TArgs) => Generator<Eval<any>, TReturn, unknown>,
-	): (...args: TArgs) => Eval<TReturn> {
-		return (...args) =>
-			Eval.defer(() => {
-				const gen = f(...args);
-				return Eval.#step(gen, gen.next());
-			});
-	}
-
-	/**
 	 * Reduce a finite iterable from left to right in the context of `Eval`.
 	 *
 	 * @remarks

--- a/src/eval.ts
+++ b/src/eval.ts
@@ -565,7 +565,7 @@ export namespace Eval {
 	/**
 	 *
 	 */
-	export type Go<TReturn> = Generator<Eval<any>, TReturn, unknown>;
+	export type Go<TReturn> = Generator<Eval<unknown>, TReturn, unknown>;
 
 	/**
 	 * Extract the outcome type `T` from the type `Eval<T>`.

--- a/src/ior.test.ts
+++ b/src/ior.test.ts
@@ -204,21 +204,6 @@ describe("Ior", () => {
 		});
 	});
 
-	describe("goFn", () => {
-		it("accesses the parameters of the generator function", () => {
-			const f = Ior.goFn(function* <T>(w: T) {
-				const x = yield* Ior.both<Str, 2>(new Str("a"), 2);
-				const [y, z] = yield* Ior.both(
-					new Str("b"),
-					tuple<[2, 4]>(x, 4),
-				);
-				return tuple(w, x, y, z);
-			});
-			const ior = f<0>(0);
-			expect(ior).to.deep.equal(Ior.both(new Str("ab"), [0, 2, 2, 4]));
-		});
-	});
-
 	describe("reduce", () => {
 		it("reduces the finite iterable from left to right in the context of Ior", () => {
 			const ior = Ior.reduce(
@@ -401,22 +386,6 @@ describe("Ior", () => {
 				}
 			});
 			expect(ior).to.deep.equal(Ior.left(new Str("ab")));
-		});
-	});
-
-	describe("goAsyncFn", () => {
-		it("accesses the parameters of the async generator function", async () => {
-			const f = Ior.goAsyncFn(async function* <T>(w: T) {
-				const x = yield* await Promise.resolve(
-					Ior.both<Str, 2>(new Str("a"), 2),
-				);
-				const [y, z] = yield* await Promise.resolve(
-					Ior.both(new Str("b"), tuple<[2, 4]>(x, 4)),
-				);
-				return tuple(w, x, y, z);
-			});
-			const ior = await f<0>(0);
-			expect(ior).to.deep.equal(Ior.both(new Str("ab"), [0, 2, 2, 4]));
 		});
 	});
 

--- a/src/ior.test.ts
+++ b/src/ior.test.ts
@@ -98,70 +98,76 @@ describe("Ior", () => {
 
 	describe("go", () => {
 		it("short-circuits on the first yielded Left", () => {
-			const ior = Ior.go(function* () {
+			function* f(): Ior.Go<Str, [2, 2, 4]> {
 				const x = yield* Ior.right<2, Str>(2);
 				expect(x).to.equal(2);
 				const [y, z] = yield* Ior.left<Str, [2, 4]>(new Str("b"));
 				return tuple(x, y, z);
-			});
+			}
+			const ior = Ior.go(f());
 			expect(ior).to.deep.equal(Ior.left(new Str("b")));
 		});
 
 		it("completes if all yielded values are Right", () => {
-			const ior = Ior.go(function* () {
+			function* f(): Ior.Go<Str, [2, 2, 4]> {
 				const x = yield* Ior.right<2, Str>(2);
 				const [y, z] = yield* Ior.right<[2, 4], Str>([x, 4]);
 				return tuple(x, y, z);
-			});
+			}
+			const ior = Ior.go(f());
 			expect(ior).to.deep.equal(Ior.right([2, 2, 4]));
 		});
 
 		it("completes and retains the left-hand value if a Both is yielded after a Right", () => {
-			const ior = Ior.go(function* () {
+			function* f(): Ior.Go<Str, [2, 2, 4]> {
 				const x = yield* Ior.right<2, Str>(2);
 				const [y, z] = yield* Ior.both(
 					new Str("b"),
 					tuple<[2, 4]>(x, 4),
 				);
 				return tuple(x, y, z);
-			});
+			}
+			const ior = Ior.go(f());
 			expect(ior).to.deep.equal(Ior.both(new Str("b"), [2, 2, 4]));
 		});
 
 		it("short-circuits and combines the left-hand values if a Left is yielded after a Both", () => {
-			const ior = Ior.go(function* () {
+			function* f(): Ior.Go<Str, [2, 2, 4]> {
 				const x = yield* Ior.both<Str, 2>(new Str("a"), 2);
 				expect(x).to.equal(2);
 				const [y, z] = yield* Ior.left<Str, [2, 4]>(new Str("b"));
 				return tuple(x, y, z);
-			});
+			}
+			const ior = Ior.go(f());
 			expect(ior).to.deep.equal(Ior.left(new Str("ab")));
 		});
 
 		it("completes and retains the left-hand value if a Right is yielded after a Both", () => {
-			const ior = Ior.go(function* () {
+			function* f(): Ior.Go<Str, [2, 2, 4]> {
 				const x = yield* Ior.both<Str, 2>(new Str("a"), 2);
 				const [y, z] = yield* Ior.right<[2, 4], Str>([x, 4]);
 				return tuple(x, y, z);
-			});
+			}
+			const ior = Ior.go(f());
 			expect(ior).to.deep.equal(Ior.both(new Str("a"), [2, 2, 4]));
 		});
 
 		it("completes and combines the left-hand values if a Both is yielded after a Both", () => {
-			const ior = Ior.go(function* () {
+			function* f(): Ior.Go<Str, [2, 2, 4]> {
 				const x = yield* Ior.both<Str, 2>(new Str("a"), 2);
 				const [y, z] = yield* Ior.both(
 					new Str("b"),
 					tuple<[2, 4]>(x, 4),
 				);
 				return tuple(x, y, z);
-			});
+			}
+			const ior = Ior.go(f());
 			expect(ior).to.deep.equal(Ior.both(new Str("ab"), [2, 2, 4]));
 		});
 
 		it("executes the finally block if a Left is yielded in the try block", () => {
 			const logs: string[] = [];
-			const ior = Ior.go(function* () {
+			function* f(): Ior.Go<Str, number[]> {
 				try {
 					const results = [];
 					const x = yield* Ior.left<Str, 2>(new Str("a"));
@@ -170,13 +176,14 @@ describe("Ior", () => {
 				} finally {
 					logs.push("finally");
 				}
-			});
+			}
+			const ior = Ior.go(f());
 			expect(ior).to.deep.equal(Ior.left(new Str("a")));
 			expect(logs).to.deep.equal(["finally"]);
 		});
 
 		it("combines the left-hand values of two Left variants across the try...finally block", () => {
-			const ior = Ior.go(function* () {
+			function* f(): Ior.Go<Str, number[]> {
 				try {
 					const results = [];
 					const x = yield* Ior.left<Str, 2>(new Str("a"));
@@ -185,12 +192,13 @@ describe("Ior", () => {
 				} finally {
 					yield* Ior.left<Str, 4>(new Str("b"));
 				}
-			});
+			}
+			const ior = Ior.go(f());
 			expect(ior).to.deep.equal(Ior.left(new Str("ab")));
 		});
 
 		it("combines the left-hand values of a Left variant and a Both variant across the try...finally block", () => {
-			const ior = Ior.go(function* () {
+			function* f(): Ior.Go<Str, number[]> {
 				try {
 					const results = [];
 					const x = yield* Ior.left<Str, 2>(new Str("a"));
@@ -199,7 +207,8 @@ describe("Ior", () => {
 				} finally {
 					yield* Ior.both<Str, 4>(new Str("b"), 4);
 				}
-			});
+			}
+			const ior = Ior.go(f());
 			expect(ior).to.deep.equal(Ior.left(new Str("ab")));
 		});
 	});
@@ -247,41 +256,44 @@ describe("Ior", () => {
 
 	describe("goAsync", async () => {
 		it("short-circuits on the first yielded Left", async () => {
-			const ior = await Ior.goAsync(async function* () {
+			async function* f(): Ior.GoAsync<Str, [2, 2, 4]> {
 				const x = yield* await Promise.resolve(Ior.right<2, Str>(2));
 				expect(x).to.equal(2);
 				const [y, z] = yield* await Promise.resolve(
 					Ior.left<Str, [2, 4]>(new Str("b")),
 				);
 				return tuple(x, y, z);
-			});
+			}
+			const ior = await Ior.goAsync(f());
 			expect(ior).to.deep.equal(Ior.left(new Str("b")));
 		});
 
 		it("completes if all yielded values are Right", async () => {
-			const ior = await Ior.goAsync(async function* () {
+			async function* f(): Ior.GoAsync<Str, [2, 2, 4]> {
 				const x = yield* await Promise.resolve(Ior.right<2, Str>(2));
 				const [y, z] = yield* await Promise.resolve(
 					Ior.right<[2, 4], Str>([x, 4]),
 				);
 				return tuple(x, y, z);
-			});
+			}
+			const ior = await Ior.goAsync(f());
 			expect(ior).to.deep.equal(Ior.right([2, 2, 4]));
 		});
 
 		it("completes and retains the left-hand value if a Both is yielded after a Right", async () => {
-			const ior = await Ior.goAsync(async function* () {
+			async function* f(): Ior.GoAsync<Str, [2, 2, 4]> {
 				const x = yield* await Promise.resolve(Ior.right<2, Str>(2));
 				const [y, z] = yield* await Promise.resolve(
 					Ior.both(new Str("b"), tuple<[2, 4]>(x, 4)),
 				);
 				return tuple(x, y, z);
-			});
+			}
+			const ior = await Ior.goAsync(f());
 			expect(ior).to.deep.equal(Ior.both(new Str("b"), [2, 2, 4]));
 		});
 
 		it("short-circuits and combines the left-hand values if a Left is yielded after a Both", async () => {
-			const ior = await Ior.goAsync(async function* () {
+			async function* f(): Ior.GoAsync<Str, [2, 2, 4]> {
 				const x = yield* await Promise.resolve(
 					Ior.both<Str, 2>(new Str("a"), 2),
 				);
@@ -290,12 +302,13 @@ describe("Ior", () => {
 					Ior.left<Str, [2, 4]>(new Str("b")),
 				);
 				return tuple(x, y, z);
-			});
+			}
+			const ior = await Ior.goAsync(f());
 			expect(ior).to.deep.equal(Ior.left(new Str("ab")));
 		});
 
 		it("completes and retains the left-hand value if a Right is yielded after a Both", async () => {
-			const ior = await Ior.goAsync(async function* () {
+			async function* f(): Ior.GoAsync<Str, [2, 2, 4]> {
 				const x = yield* await Promise.resolve(
 					Ior.both<Str, 2>(new Str("a"), 2),
 				);
@@ -303,12 +316,13 @@ describe("Ior", () => {
 					Ior.right<[2, 4], Str>([x, 4]),
 				);
 				return tuple(x, y, z);
-			});
+			}
+			const ior = await Ior.goAsync(f());
 			expect(ior).to.deep.equal(Ior.both(new Str("a"), [2, 2, 4]));
 		});
 
 		it("completes and combines the left-hand values if a Both is yielded after", async () => {
-			const ior = await Ior.goAsync(async function* () {
+			async function* f(): Ior.GoAsync<Str, [2, 2, 4]> {
 				const x = yield* await Promise.resolve(
 					Ior.both<Str, 2>(new Str("a"), 2),
 				);
@@ -316,12 +330,13 @@ describe("Ior", () => {
 					Ior.both(new Str("b"), tuple<[2, 4]>(x, 4)),
 				);
 				return tuple(x, y, z);
-			});
+			}
+			const ior = await Ior.goAsync(f());
 			expect(ior).to.deep.equal(Ior.both(new Str("ab"), [2, 2, 4]));
 		});
 
 		it("unwraps Promises in right-hand channels and in return", async () => {
-			const ior = await Ior.goAsync(async function* () {
+			async function* f(): Ior.GoAsync<Str, [2, 2, 4]> {
 				const x = yield* await Promise.resolve(
 					Ior.both<Str, Promise<2>>(new Str("a"), Promise.resolve(2)),
 				);
@@ -332,13 +347,14 @@ describe("Ior", () => {
 					),
 				);
 				return Promise.resolve(tuple(x, y, z));
-			});
+			}
+			const ior = await Ior.goAsync(f());
 			expect(ior).to.deep.equal(Ior.both(new Str("ab"), [2, 2, 4]));
 		});
 
 		it("executes the finally block if a Left is yielded in the try block", async () => {
 			const logs: string[] = [];
-			const ior = await Ior.goAsync(async function* () {
+			async function* f(): Ior.GoAsync<Str, number[]> {
 				try {
 					const results = [];
 					const x = yield* await Promise.resolve(
@@ -349,13 +365,14 @@ describe("Ior", () => {
 				} finally {
 					logs.push("finally");
 				}
-			});
+			}
+			const ior = await Ior.goAsync(f());
 			expect(ior).to.deep.equal(Ior.left(new Str("a")));
 			expect(logs).to.deep.equal(["finally"]);
 		});
 
 		it("combines the left-hand values of two Left variants across the try...finally block", async () => {
-			const ior = await Ior.goAsync(async function* () {
+			async function* f(): Ior.GoAsync<Str, number[]> {
 				try {
 					const results = [];
 					const x = yield* await Promise.resolve(
@@ -366,12 +383,13 @@ describe("Ior", () => {
 				} finally {
 					yield* Ior.left<Str, 4>(new Str("b"));
 				}
-			});
+			}
+			const ior = await Ior.goAsync(f());
 			expect(ior).to.deep.equal(Ior.left(new Str("ab")));
 		});
 
 		it("combines the left-hand values of a Left variant and a Both variant across the try...finally block", async () => {
-			const ior = await Ior.goAsync(async function* () {
+			async function* f(): Ior.GoAsync<Str, number[]> {
 				try {
 					const results = [];
 					const x = yield* await Promise.resolve(
@@ -384,7 +402,8 @@ describe("Ior", () => {
 						Ior.both<Str, 4>(new Str("b"), 4),
 					);
 				}
-			});
+			}
+			const ior = await Ior.goAsync(f());
 			expect(ior).to.deep.equal(Ior.left(new Str("ab")));
 		});
 	});

--- a/src/ior.test.ts
+++ b/src/ior.test.ts
@@ -811,6 +811,57 @@ describe("Ior", () => {
 		});
 	});
 
+	describe("#goMap", () => {
+		it("does not apply the continuation if the variant is Left", () => {
+			const ior = Ior.left<Str, 2>(new Str("a")).goMap(function* (x) {
+				const y = yield* Ior.both<Str, 4>(new Str("b"), 4);
+				return [x, y] as [2, 4];
+			});
+			expect(ior).to.deep.equal(Ior.left(new Str("a")));
+		});
+
+		it("applies the continuation to the value if the variant is Right", () => {
+			const ior = Ior.right<2, Str>(2).goMap(function* (x) {
+				const y = yield* Ior.right<4, Str>(4);
+				return [x, y] as [2, 4];
+			});
+			expect(ior).to.deep.equal(Ior.right([2, 4]));
+		});
+
+		it("retains the left-hand value if the continuation on a Right returns a Both", () => {
+			const ior = Ior.right<2, Str>(2).goMap(function* (x) {
+				const y = yield* Ior.both<Str, 4>(new Str("b"), 4);
+				return [x, y] as [2, 4];
+			});
+			expect(ior).to.deep.equal(Ior.both(new Str("b"), [2, 4]));
+		});
+
+		it("combines the left-hand values if the continuation on a Both returns a Left", () => {
+			const ior = Ior.both<Str, 2>(new Str("a"), 2).goMap(function* (x) {
+				expect(x).to.equal(2);
+				const y = yield* Ior.left<Str, 4>(new Str("b"));
+				return [x, y] as [2, 4];
+			});
+			expect(ior).to.deep.equal(Ior.left(new Str("ab")));
+		});
+
+		it("retains the left-hand value if the continuation on a Both returns a Right", () => {
+			const ior = Ior.both<Str, 2>(new Str("a"), 2).goMap(function* (x) {
+				const y = yield* Ior.right<4, Str>(4);
+				return [x, y] as [2, 4];
+			});
+			expect(ior).to.deep.equal(Ior.both(new Str("a"), [2, 4]));
+		});
+
+		it("combines the left-hand values if the continuation on a Both returns a Both", () => {
+			const ior = Ior.both<Str, 2>(new Str("a"), 2).goMap(function* (x) {
+				const y = yield* Ior.both<Str, 4>(new Str("b"), 4);
+				return [x, y] as [2, 4];
+			});
+			expect(ior).to.deep.equal(Ior.both(new Str("ab"), [2, 4]));
+		});
+	});
+
 	describe("#zipWith", () => {
 		it("applies the function to the right-hand values if both variants have right-hand values", () => {
 			const ior = Ior.both<Str, 2>(new Str("a"), 2).zipWith(

--- a/src/ior.ts
+++ b/src/ior.ts
@@ -468,7 +468,7 @@ export namespace Ior {
 	}
 
 	/**
-	 *
+	 * Interpret an `Ior.Go` generator to return an `Ior`.
 	 */
 	export function go<A extends Semigroup<A>, TReturn>(
 		gen: Go<A, TReturn>,
@@ -635,7 +635,8 @@ export namespace Ior {
 	}
 
 	/**
-	 *
+	 * Interpret an `Ior.GoAsync` async generator to return a `Promise` that
+	 * resolves with an `Ior`.
 	 */
 	export async function goAsync<A extends Semigroup<A>, TReturn>(
 		gen: GoAsync<A, TReturn>,
@@ -841,7 +842,12 @@ export namespace Ior {
 		}
 
 		/**
-		 *
+		 * If this `Ior` has a right-hand value, apply a generator comprehension
+		 * function to the value and interpret the `Ior.Go` generator to return
+		 * another `Ior`. Accumulate the left-hand values of `Both` variants
+		 * using their behavior as a semigroup. If either `Ior` is a `Left`,
+		 * combine the left-hand value with any existing left-hand value and
+		 * return the result in a `Left`.
 		 */
 		goMap<A extends Semigroup<A>, B, B1>(
 			this: Ior<A, B>,
@@ -953,13 +959,11 @@ export namespace Ior {
 		}
 
 		/**
-		 * Defining iterable behavior for `Ior` allows TypeScript to infer
-		 * right-hand value types when yielding `Ior` values in generator
-		 * comprehensions using `yield*`.
-		 *
-		 * @hidden
+		 * Return an `Ior.Go` generator that yields this `Ior` and returns its
+		 * right-hand value if one is present. This allows `Ior` values to be
+		 * yielded directly in `Ior` generator comprehensions using `yield*`.
 		 */
-		*[Symbol.iterator](): Iterator<Ior<A, never>, never, unknown> {
+		*[Symbol.iterator](): Generator<Ior<A, never>, never, unknown> {
 			return (yield this) as never;
 		}
 	}
@@ -984,13 +988,11 @@ export namespace Ior {
 		}
 
 		/**
-		 * Defining iterable behavior for `Ior` allows TypeScript to infer
-		 * right-hand value types when yielding `Ior` values in generator
-		 * comprehensions using `yield*`.
-		 *
-		 * @hidden
+		 * Return an `Ior.Go` generator that yields this `Ior` and returns its
+		 * right-hand value if one is present. This allows `Ior` values to be
+		 * yielded directly in `Ior` generator comprehensions using `yield*`.
 		 */
-		*[Symbol.iterator](): Iterator<Ior<never, B>, B, unknown> {
+		*[Symbol.iterator](): Generator<Ior<never, B>, B, unknown> {
 			return (yield this) as B;
 		}
 	}
@@ -1028,19 +1030,17 @@ export namespace Ior {
 		}
 
 		/**
-		 * Defining iterable behavior for `Ior` allows TypeScript to infer
-		 * right-hand value types when yielding `Ior` values in generator
-		 * comprehensions using `yield*`.
-		 *
-		 * @hidden
+		 * Return an `Ior.Go` generator that yields this `Ior` and returns its
+		 * right-hand value if one is present. This allows `Ior` values to be
+		 * yielded directly in `Ior` generator comprehensions using `yield*`.
 		 */
-		*[Symbol.iterator](): Iterator<Ior<A, B>, B, unknown> {
+		*[Symbol.iterator](): Generator<Ior<A, B>, B, unknown> {
 			return (yield this) as B;
 		}
 	}
 
 	/**
-	 *
+	 * A generator that yields `Ior` values and may return a result.
 	 */
 	export type Go<A extends Semigroup<A>, TReturn> = Generator<
 		Ior<A, unknown>,
@@ -1049,7 +1049,7 @@ export namespace Ior {
 	>;
 
 	/**
-	 *
+	 * An async generator that yields `Ior` values and may return a result.
 	 */
 	export type GoAsync<A extends Semigroup<A>, TReturn> = AsyncGenerator<
 		Ior<A, unknown>,

--- a/src/ior.ts
+++ b/src/ior.ts
@@ -1078,7 +1078,7 @@ export namespace Ior {
 	 *
 	 */
 	export type Go<A extends Semigroup<A>, TReturn> = Generator<
-		Ior<A, any>,
+		Ior<A, unknown>,
 		TReturn,
 		unknown
 	>;
@@ -1087,7 +1087,7 @@ export namespace Ior {
 	 *
 	 */
 	export type GoAsync<A extends Semigroup<A>, TReturn> = AsyncGenerator<
-		Ior<A, any>,
+		Ior<A, unknown>,
 		TReturn,
 		unknown
 	>;

--- a/src/ior.ts
+++ b/src/ior.ts
@@ -177,7 +177,7 @@
  * Each `yield*` expression may bind a variable of the right-hand value type of
  * the yielded `Ior`. Comprehensions should always use `yield*` instead of
  * `yield`. Using `yield*` allows TypeScript to accurately infer the right-hand
- * value type of each yielded `Ior` when binding the value of a `yield*`
+ * value type of the yielded `Ior` when binding the value of each `yield*`
  * expression.
  *
  * Comprehensions require that the left-hand values of all yielded `Ior` values

--- a/src/ior.ts
+++ b/src/ior.ts
@@ -886,6 +886,16 @@ export namespace Ior {
 		}
 
 		/**
+		 *
+		 */
+		goMap<A extends Semigroup<A>, B, B1>(
+			this: Ior<A, B>,
+			f: (val: B) => Go<A, B1>,
+		): Ior<A, B1> {
+			return this.flatMap((val) => go(f(val)));
+		}
+
+		/**
 		 * If this and that `Ior` have a right-hand value, apply a function to
 		 * the values and return the result as a right-hand value. Accumulate
 		 * the left-hand values of `Both` variants using their behavior as a

--- a/src/ior.ts
+++ b/src/ior.ts
@@ -629,7 +629,7 @@ export namespace Ior {
 		LeftT<TIors[keyof TIors]>,
 		{ -readonly [K in keyof TIors]: RightT<TIors[K]> }
 	> {
-		return Ior.go(
+		return go(
 			(function* (): Ior.Go<any, any> {
 				const results: Record<any, any> = {};
 				for (const [key, ior] of Object.entries(iors)) {

--- a/src/ior.ts
+++ b/src/ior.ts
@@ -171,7 +171,7 @@
  * type. An async generator function that returns an `Ior.GoAsync<A, T>` may
  * `yield*` zero or more `Ior<A, any>` values and must return a result of type
  * `T`. `PromiseLike` values that resolve with `Ior` should be awaited before
- * yielding. Async comprehensions may also `yieid*` other `Ior.Go` and
+ * yielding. Async comprehensions may also `yield*` other `Ior.Go` and
  * `Ior.GoAsync` generators directly.
  *
  * Each `yield*` expression may bind a variable of the right-hand value type of

--- a/src/ior.ts
+++ b/src/ior.ts
@@ -189,7 +189,7 @@
  * `Ior.Go` and `Ior.GoAsync` generators must be evaluated before accessing
  * their results.
  *
- * The `go` function evaluates an `Ior.Go<A, T> generator to return an `Ior<A,
+ * The `go` function evaluates an `Ior.Go<A, T>` generator to return an `Ior<A,
  * T>`. If any yielded `Ior` is a `Left`, the generator halts and the left-hand
  * value is combined with any existing left-hand value, and `go` returns the
  * result in a `Left`; otherwise, when the generator returns, `go` returns the

--- a/src/ior.ts
+++ b/src/ior.ts
@@ -628,24 +628,6 @@ export namespace Ior {
 	}
 
 	/**
-	 * Construct a function that returns an `Ior` using a generator
-	 * comprehension.
-	 *
-	 * @remarks
-	 *
-	 * This is the higher-order function variant of `go`.
-	 */
-	export function goFn<
-		TArgs extends unknown[],
-		A extends Semigroup<A>,
-		TReturn,
-	>(
-		f: (...args: TArgs) => Generator<Ior<A, any>, TReturn, unknown>,
-	): (...args: TArgs) => Ior<A, TReturn> {
-		return (...args) => step(f(...args));
-	}
-
-	/**
 	 * Reduce a finite iterable from left to right in the context of `Ior`.
 	 *
 	 * @remarks
@@ -847,24 +829,6 @@ export namespace Ior {
 		f: () => AsyncGenerator<Ior<A, any>, TReturn, unknown>,
 	): Promise<Ior<A, TReturn>> {
 		return stepAsync(f());
-	}
-
-	/**
-	 * Construct a function that returns a `Promise` that fulfills with an `Ior`
-	 * using an async generator comprehension.
-	 *
-	 * @remarks
-	 *
-	 * This is the higher-order function variant of `goAsync`.
-	 */
-	export function goAsyncFn<
-		TArgs extends unknown[],
-		A extends Semigroup<A>,
-		TReturn,
-	>(
-		f: (...args: TArgs) => AsyncGenerator<Ior<A, any>, TReturn, unknown>,
-	): (...args: TArgs) => Promise<Ior<A, TReturn>> {
-		return (...args) => stepAsync(f(...args));
 	}
 
 	/**

--- a/src/ior.ts
+++ b/src/ior.ts
@@ -611,17 +611,14 @@ export namespace Ior {
 		{ -readonly [K in keyof TIors]: RightT<TIors[K]> }
 	> {
 		return go(
-			(function* () {
+			(function* (): Ior.Go<any, any> {
 				const results = new Array(iors.length);
 				for (const [idx, ior] of iors.entries()) {
 					results[idx] = yield* ior;
 				}
 				return results;
 			})(),
-		) as Ior<
-			LeftT<TIors[number]>,
-			{ [K in keyof TIors]: RightT<TIors[K]> }
-		>;
+		);
 	}
 
 	/**
@@ -649,17 +646,14 @@ export namespace Ior {
 		{ -readonly [K in keyof TIors]: RightT<TIors[K]> }
 	> {
 		return Ior.go(
-			(function* () {
+			(function* (): Ior.Go<any, any> {
 				const results: Record<any, any> = {};
 				for (const [key, ior] of Object.entries(iors)) {
 					results[key] = yield* ior;
 				}
 				return results;
 			})(),
-		) as Ior<
-			LeftT<TIors[keyof TIors]>,
-			{ [K in keyof TIors]: RightT<TIors[K]> }
-		>;
+		);
 	}
 
 	/**

--- a/src/ior.ts
+++ b/src/ior.ts
@@ -150,31 +150,60 @@
  * the left-hand value is combined with any existing left-hand value, and the
  * result is returned in a `Left`.
  *
- * ### Generator comprehensions
+ * ## Generator comprehenshions
  *
  * Generator comprehensions provide an imperative syntax for chaining together
- * computations that return `Ior`. Instead of `flatMap`, a generator is used
- * to unwrap `Ior` values and apply functions to right-hand values.
+ * synchronous or asynchronous computations that return or resolve with `Ior`
+ * values.
  *
- * The `go` function evaluates a generator to return an `Ior`. Within the
- * generator, `Ior` values are yielded using the `yield*` keyword. If a yielded
- * `Ior` has a right-hand value, the value may be bound to a specified variable.
- * The left-hand values of `Both` variants accumulate using their behavior as a
- * semigroup. If any yielded `Ior` is a `Left`, the generator halts and the
- * left-hand value is combined with any existing left-hand value, and the result
- * is returned in a `Left`; otherwise, when the computation is complete, the
- * generator may return a final result and `go` returns the result as a
- * right-hand value.
+ * ### Writing comprehensions
  *
- * ## Async generator comprehensions
+ * Synchronus and asynchronous comprehensions are written using `function*` and
+ * `async function*` declarations, respectively.
  *
- * Async generator comprehensions provide `async`/`await` syntax to `Ior`
- * generator comprehensions, allowing promise-like computations that fulfill
- * with `Ior` to be chained together using the familiar generator syntax.
+ * Synchronous generator functions should use the `Ior.Go` type alias as a
+ * return type. A generator function that returns an `Ior.Go<A, T>` may `yield*`
+ * zero or more `Ior<A, any>` values and must return a result of type `T`.
+ * Synchronous comprehensions may also `yield*` other `Ior.Go` generators
+ * directly.
  *
- * The `goAsync` function evaluates an async generator to return a `Promise`
- * that fulfills with an `Ior`. The semantics of `yield*` and `return` within
- * async comprehensions are identical to their synchronous counterparts.
+ * Async generator functions should use the `Ior.GoAsync` type alias as a return
+ * type. An async generator function that returns an `Ior.GoAsync<A, T>` may
+ * `yield*` zero or more `Ior<A, any>` values and must return a result of type
+ * `T`. `PromiseLike` values that resolve with `Ior` should be awaited before
+ * yielding. Async comprehensions may also `yieid*` other `Ior.Go` and
+ * `Ior.GoAsync` generators directly.
+ *
+ * Each `yield*` expression may bind a variable of the right-hand value type of
+ * the yielded `Ior`. Comprehensions should always use `yield*` instead of
+ * `yield`. Using `yield*` allows TypeScript to accurately infer the right-hand
+ * value type of each yielded `Ior` when binding the value of a `yield*`
+ * expression.
+ *
+ * Comprehensions require that the left-hand values of all yielded `Ior` values
+ * are implementors of the same `Semigroup` so the values may accumulate as the
+ * generator yields.
+ *
+ * ### Evaluating comprehensions
+ *
+ * `Ior.Go` and `Ior.GoAsync` generators must be evaluated before accessing
+ * their results.
+ *
+ * The `go` function evaluates an `Ior.Go<A, T> generator to return an `Ior<A,
+ * T>`. If any yielded `Ior` is a `Left`, the generator halts and the left-hand
+ * value is combined with any existing left-hand value, and `go` returns the
+ * result in a `Left`; otherwise, when the generator returns, `go` returns the
+ * result as a right-hand value.
+ *
+ * The `goAsync` function evaluates an `Ior.GoAsync<A, T>` async generator to
+ * return a `Promise<Ior<A, T>>`. If any yielded `Ior` is a `Left`, the
+ * generator halts and the left-hand value is combined with any existing
+ * left-hand value, and `goAsync` resolves with the result in a `Left`;
+ * otherwise, when the generator returns, `goAsync` resolves with the result as
+ * a right-hand value. Thrown errors are captured as rejections.
+ *
+ * In both synchronous and asynchronous comprehensions, the left-hand values of
+ * yielded `Both` variants accumulate using their behavior as a semigroup.
  *
  * ## Collecting into `Ior`
  *

--- a/src/ior.ts
+++ b/src/ior.ts
@@ -520,6 +520,7 @@ export namespace Ior {
 	): Ior<A, TReturn> {
 		let nxt = gen.next();
 		let acc: A | undefined;
+		let isHalted = false;
 
 		while (!nxt.done) {
 			const ior = nxt.value;
@@ -538,18 +539,18 @@ export namespace Ior {
 				} else {
 					acc = cmb(acc, ior.val);
 				}
-				nxt = gen.return(halt as any);
+				isHalted = true;
+				nxt = gen.return(undefined as any);
 			}
 		}
 
-		const result = nxt.value;
-		if (result === halt) {
+		if (isHalted) {
 			return left(acc as A);
 		}
 		if (acc === undefined) {
-			return right(result);
+			return right(nxt.value);
 		}
-		return both(acc, result);
+		return both(acc, nxt.value);
 	}
 
 	/**
@@ -692,6 +693,7 @@ export namespace Ior {
 	): Promise<Ior<A, TReturn>> {
 		let nxt = await gen.next();
 		let acc: A | undefined;
+		let isHalted = false;
 
 		while (!nxt.done) {
 			const ior = nxt.value;
@@ -710,18 +712,18 @@ export namespace Ior {
 				} else {
 					acc = cmb(acc, ior.val);
 				}
-				nxt = await gen.return(halt as any);
+				isHalted = true;
+				nxt = await gen.return(undefined as any);
 			}
 		}
 
-		const result = nxt.value;
-		if (result === halt) {
+		if (isHalted) {
 			return left(acc as A);
 		}
 		if (acc === undefined) {
-			return right(result);
+			return right(nxt.value);
 		}
-		return both(acc, result);
+		return both(acc, nxt.value);
 	}
 
 	/**
@@ -1113,9 +1115,4 @@ export namespace Ior {
 	]
 		? B
 		: never;
-
-	// A unique symbol used by the `Ior` generator comprehension implementation
-	// to signal the underlying generator to return early. This ensures
-	// `try...finally` blocks can execute.
-	const halt = Symbol();
 }

--- a/src/ior.ts
+++ b/src/ior.ts
@@ -319,19 +319,6 @@
  * // input "0x2A: [["info: parse '0x2A' ok"],42]
  * ```
  *
- * We can refactor the `parseEvenInt` function to use a generator comprehension
- * instead:
- *
- * ```ts
- * function parseEvenInt(input: string): Ior<Log, number> {
- *     return Ior.go(function* () {
- *         const n = yield* parseInt(input);
- *         const even = yield* guardEven(n);
- *         return even;
- *     });
- * }
- * ```
- *
  * Suppose we want to parse an array of inputs and collect the successful
  * results, or fail on the first parse error. We may write the following:
  *
@@ -357,40 +344,8 @@
  * //   [["info: parse '+42' ok","info: parse '0x2A' ok"],[42,42]]
  * ```
  *
- * Perhaps we want to collect only distinct even numbers using a Set:
- *
- * ```ts
- * function parseEvenIntsUniq(inputs: string[]): Ior<Log, Set<number>> {
- *     return Ior.go(function* () {
- *         const results = new Set<number>();
- *         for (const input of inputs) {
- *             results.add(yield* parseEvenInt(input));
- *         }
- *         return results;
- *     });
- * }
- *
- * [
- *     ["a", "-4"],
- *     ["2", "-7"],
- *     ["+42", "0x2A"],
- * ].forEach((inputs) => {
- *     const result = JSON.stringify(
- *         parseEvenIntsUniq(inputs).map(Array.from).val,
- *     );
- *     console.log(`inputs ${JSON.stringify(inputs)}:\n  ${result}`);
- * });
- *
- * // inputs ["a","-4"]:
- * //   ["err: cannot parse 'a' as int"]
- * // inputs ["2","-7"]:
- * //   ["info: parse '2' ok","info: parse '-7' ok","err: -7 is not even"]
- * // inputs ["+42" "0x2A"]:
- * //   [["info: parse '+42' ok","info: parse '0x2A' ok"],[42]]
- * ```
- *
- * Or, perhaps we want to associate the original input strings with our
- * successful parses:
+ * Perhaps we want to associate the original input strings with our successful
+ * parses:
  *
  * ```ts
  * function parseEvenIntsKeyed(

--- a/src/ior.ts
+++ b/src/ior.ts
@@ -497,7 +497,7 @@ export namespace Ior {
 	}
 
 	/**
-	 * Interpret an `Ior.Go` generator to return an `Ior`.
+	 * Evaluate an `Ior.Go` generator to return an `Ior`.
 	 */
 	export function go<A extends Semigroup<A>, TReturn>(
 		gen: Go<A, TReturn>,
@@ -664,7 +664,7 @@ export namespace Ior {
 	}
 
 	/**
-	 * Interpret an `Ior.GoAsync` async generator to return a `Promise` that
+	 * Evaluate an `Ior.GoAsync` async generator to return a `Promise` that
 	 * resolves with an `Ior`.
 	 */
 	export async function goAsync<A extends Semigroup<A>, TReturn>(
@@ -872,7 +872,7 @@ export namespace Ior {
 
 		/**
 		 * If this `Ior` has a right-hand value, apply a generator comprehension
-		 * function to the value and interpret the `Ior.Go` generator to return
+		 * function to the value and evaluate the `Ior.Go` generator to return
 		 * another `Ior`. Accumulate the left-hand values of `Both` variants
 		 * using their behavior as a semigroup. If either `Ior` is a `Left`,
 		 * combine the left-hand value with any existing left-hand value and

--- a/src/maybe.test.ts
+++ b/src/maybe.test.ts
@@ -479,6 +479,24 @@ describe("Maybe", () => {
 		});
 	});
 
+	describe("#goMap", () => {
+		it("does not apply the continuation if the variant is Nothing", () => {
+			const maybe = nothing<1>().goMap(function* (x) {
+				const y = yield* Maybe.just<2>(2);
+				return [x, y] as [1, 2];
+			});
+			expect(maybe).to.equal(Maybe.nothing);
+		});
+
+		it("applies the continuation to the value if the variant is Just", () => {
+			const maybe = Maybe.just<1>(1).goMap(function* (x) {
+				const y = yield* Maybe.just<2>(2);
+				return [x, y] as [1, 2];
+			});
+			expect(maybe).to.deep.equal(Maybe.just([1, 2]));
+		});
+	});
+
 	describe("#mapNullish", () => {
 		it("does not apply the continuation if the variant is Nothing", () => {
 			const maybe = nothing<1>().mapNullish((x): [1, 2] | null => [x, 2]);

--- a/src/maybe.test.ts
+++ b/src/maybe.test.ts
@@ -106,26 +106,28 @@ describe("Maybe", () => {
 
 	describe("go", () => {
 		it("short-circuits on the first yielded Nothing", () => {
-			const maybe = Maybe.go(function* () {
+			function* f(): Maybe.Go<[1, 1, 2]> {
 				const x = yield* Maybe.just<1>(1);
 				const [y, z] = yield* nothing<[1, 2]>();
 				return tuple(x, y, z);
-			});
+			}
+			const maybe = Maybe.go(f());
 			expect(maybe).to.equal(Maybe.nothing);
 		});
 
 		it("completes if all yielded values are Just", () => {
-			const maybe = Maybe.go(function* () {
+			function* f(): Maybe.Go<[1, 1, 2]> {
 				const x = yield* Maybe.just<1>(1);
 				const [y, z] = yield* Maybe.just<[1, 2]>([x, 2]);
 				return tuple(x, y, z);
-			});
+			}
+			const maybe = Maybe.go(f());
 			expect(maybe).to.deep.equal(Maybe.just([1, 1, 2]));
 		});
 
 		it("executes the finally block if Nothing is yielded in the try block", () => {
 			const logs: string[] = [];
-			const maybe = Maybe.go(function* () {
+			function* f(): Maybe.Go<number[]> {
 				try {
 					const results = [];
 					const x = yield* nothing<1>();
@@ -134,7 +136,8 @@ describe("Maybe", () => {
 				} finally {
 					logs.push("finally");
 				}
-			});
+			}
+			const maybe = Maybe.go(f());
 			expect(maybe).to.equal(Maybe.nothing);
 			expect(logs).to.deep.equal(["finally"]);
 		});
@@ -180,27 +183,29 @@ describe("Maybe", () => {
 
 	describe("goAsync", async () => {
 		it("short-circuits on the first yielded Nothing", async () => {
-			const maybe = await Maybe.goAsync(async function* () {
+			async function* f(): Maybe.GoAsync<[1, 1, 2]> {
 				const x = yield* await Promise.resolve(Maybe.just<1>(1));
 				const [y, z] = yield* await Promise.resolve(nothing<[1, 2]>());
 				return tuple(x, y, z);
-			});
+			}
+			const maybe = await Maybe.goAsync(f());
 			expect(maybe).to.equal(Maybe.nothing);
 		});
 
 		it("completes if all yielded values are Just", async () => {
-			const maybe = await Maybe.goAsync(async function* () {
+			async function* f(): Maybe.GoAsync<[1, 1, 2]> {
 				const x = yield* await Promise.resolve(Maybe.just<1>(1));
 				const [y, z] = yield* await Promise.resolve(
 					Maybe.just<[1, 2]>([x, 2]),
 				);
 				return tuple(x, y, z);
-			});
+			}
+			const maybe = await Maybe.goAsync(f());
 			expect(maybe).to.deep.equal(Maybe.just([1, 1, 2]));
 		});
 
 		it("unwraps Promises in Just variants and in return", async () => {
-			const maybe = await Maybe.goAsync(async function* () {
+			async function* f(): Maybe.GoAsync<[1, 1, 2]> {
 				const x = yield* await Promise.resolve(
 					Maybe.just(Promise.resolve<1>(1)),
 				);
@@ -208,13 +213,14 @@ describe("Maybe", () => {
 					Maybe.just(Promise.resolve<[1, 2]>([x, 2])),
 				);
 				return Promise.resolve(tuple(x, y, z));
-			});
+			}
+			const maybe = await Maybe.goAsync(f());
 			expect(maybe).to.deep.equal(Maybe.just([1, 1, 2]));
 		});
 
 		it("executes the finally block if Nothing is yielded in the try block", async () => {
 			const logs: string[] = [];
-			const maybe = await Maybe.goAsync(async function* () {
+			async function* f(): Maybe.GoAsync<number[]> {
 				try {
 					const results = [];
 					const x = yield* await Promise.resolve(nothing<1>());
@@ -223,7 +229,8 @@ describe("Maybe", () => {
 				} finally {
 					logs.push("finally");
 				}
-			});
+			}
+			const maybe = await Maybe.goAsync(f());
 			expect(maybe).to.equal(Maybe.nothing);
 			expect(logs).to.deep.equal(["finally"]);
 		});

--- a/src/maybe.test.ts
+++ b/src/maybe.test.ts
@@ -141,6 +141,18 @@ describe("Maybe", () => {
 			expect(maybe).to.equal(Maybe.nothing);
 			expect(logs).to.deep.equal(["finally"]);
 		});
+
+		it("returns Nothing if Nothing is yielded in the finally block", () => {
+			function* f(): Maybe.Go<number[]> {
+				try {
+					return [1];
+				} finally {
+					yield* nothing<1>();
+				}
+			}
+			const maybe = Maybe.go(f());
+			expect(maybe).to.equal(Maybe.nothing);
+		});
 	});
 
 	describe("reduce", () => {
@@ -233,6 +245,18 @@ describe("Maybe", () => {
 			const maybe = await Maybe.goAsync(f());
 			expect(maybe).to.equal(Maybe.nothing);
 			expect(logs).to.deep.equal(["finally"]);
+		});
+
+		it("returns Nothing if Nothing is yielded in the finally block", async () => {
+			async function* f(): Maybe.GoAsync<number[]> {
+				try {
+					return [1];
+				} finally {
+					yield* nothing<1>();
+				}
+			}
+			const maybe = await Maybe.goAsync(f());
+			expect(maybe).to.equal(Maybe.nothing);
 		});
 	});
 

--- a/src/maybe.test.ts
+++ b/src/maybe.test.ts
@@ -140,18 +140,6 @@ describe("Maybe", () => {
 		});
 	});
 
-	describe("goFn", () => {
-		it("accesses the parameters of the generator function", () => {
-			const f = Maybe.goFn(function* <T>(w: T) {
-				const x = yield* Maybe.just<1>(1);
-				const [y, z] = yield* Maybe.just<[1, 2]>([x, 2]);
-				return tuple(w, x, y, z);
-			});
-			const maybe = f<0>(0);
-			expect(maybe).to.deep.equal(Maybe.just([0, 1, 1, 2]));
-		});
-	});
-
 	describe("reduce", () => {
 		it("reduces the finite iterable from left to right in the context of Maybe", () => {
 			const maybe = Maybe.reduce(
@@ -238,20 +226,6 @@ describe("Maybe", () => {
 			});
 			expect(maybe).to.equal(Maybe.nothing);
 			expect(logs).to.deep.equal(["finally"]);
-		});
-	});
-
-	describe("goAsyncFn", () => {
-		it("accesses the parameters of the async generator function", async () => {
-			const f = Maybe.goAsyncFn(async function* <T>(w: T) {
-				const x = yield* await Promise.resolve(Maybe.just<1>(1));
-				const [y, z] = yield* await Promise.resolve(
-					Maybe.just<[1, 2]>([x, 2]),
-				);
-				return tuple(w, x, y, z);
-			});
-			const maybe = await f<0>(0);
-			expect(maybe).to.deep.equal(Maybe.just([0, 1, 1, 2]));
 		});
 	});
 

--- a/src/maybe.ts
+++ b/src/maybe.ts
@@ -872,12 +872,16 @@ export namespace Maybe {
 	/**
 	 *
 	 */
-	export type Go<TReturn> = Generator<Maybe<any>, TReturn, unknown>;
+	export type Go<TReturn> = Generator<Maybe<unknown>, TReturn, unknown>;
 
 	/**
 	 *
 	 */
-	export type GoAsync<TReturn> = AsyncGenerator<Maybe<any>, TReturn, unknown>;
+	export type GoAsync<TReturn> = AsyncGenerator<
+		Maybe<unknown>,
+		TReturn,
+		unknown
+	>;
 
 	/**
 	 * Extract the present value type `T` from the type `Maybe<T>`.

--- a/src/maybe.ts
+++ b/src/maybe.ts
@@ -474,16 +474,17 @@ export namespace Maybe {
 	 */
 	export function go<TReturn>(gen: Go<TReturn>): Maybe<TReturn> {
 		let nxt = gen.next();
+		let isHalted = false;
 		while (!nxt.done) {
 			const maybe = nxt.value;
 			if (maybe.isJust()) {
 				nxt = gen.next(maybe.val);
 			} else {
-				nxt = gen.return(halt as any);
+				isHalted = true;
+				nxt = gen.return(undefined as any);
 			}
 		}
-		const result = nxt.value;
-		return result === halt ? nothing : just(result);
+		return isHalted ? nothing : just(nxt.value);
 	}
 
 	/**
@@ -595,16 +596,17 @@ export namespace Maybe {
 		gen: GoAsync<TReturn>,
 	): Promise<Maybe<TReturn>> {
 		let nxt = await gen.next();
+		let isHalted = false;
 		while (!nxt.done) {
 			const maybe = nxt.value;
 			if (maybe.isJust()) {
 				nxt = await gen.next(maybe.val);
 			} else {
-				nxt = await gen.return(halt as any);
+				isHalted = true;
+				nxt = await gen.return(undefined as any);
 			}
 		}
-		const result = nxt.value;
-		return result === halt ? nothing : just(result);
+		return isHalted ? nothing : just(nxt.value);
 	}
 
 	/**
@@ -883,9 +885,4 @@ export namespace Maybe {
 	export type JustT<TMaybe extends Maybe<any>> = TMaybe extends Maybe<infer T>
 		? T
 		: never;
-
-	// A unique symbol used by the `Maybe` generator comprehension
-	// implementation to signal the underlying generator to return early. This
-	// ensures `try...finally` blocks can properly execute.
-	const halt = Symbol();
 }

--- a/src/maybe.ts
+++ b/src/maybe.ts
@@ -428,7 +428,7 @@ export namespace Maybe {
 	}
 
 	/**
-	 *
+	 * Interpret a `Maybe.Go` generator to return a `Maybe.`
 	 */
 	export function go<TReturn>(gen: Go<TReturn>): Maybe<TReturn> {
 		let nxt = gen.next();
@@ -548,7 +548,8 @@ export namespace Maybe {
 	}
 
 	/**
-	 *
+	 * Interpret a `Maybe.GoAsync` async generator to return a `Promise` that
+	 * resolves with a `Maybe`.
 	 */
 	export async function goAsync<TReturn>(
 		gen: GoAsync<TReturn>,
@@ -683,7 +684,9 @@ export namespace Maybe {
 		}
 
 		/**
-		 *
+		 * If this `Maybe` is present, apply a generator comprehension function
+		 * to its value and interpret the `Maybe.Go` generator to return another
+		 * `Maybe`; otherwise, return `Nothing`.
 		 */
 		goMap<T, T1>(this: Maybe<T>, f: (val: T) => Go<T1>): Maybe<T1> {
 			return this.flatMap((val) => go(f(val)));
@@ -787,13 +790,11 @@ export namespace Maybe {
 		}
 
 		/**
-		 * Defining iterable behavior for `Maybe` allows TypeScript to infer
-		 * `Just` types when yielding `Maybe` values in generator comprehensions
-		 * using `yield*`.
-		 *
-		 * @hidden
+		 * Return a `Maybe.Go` generator that yields this `Maybe` and returns
+		 * its value if one is present. This allows `Maybe` values to be yielded
+		 * directly in `Maybe` generator comprehensions using `yield*`.
 		 */
-		*[Symbol.iterator](): Iterator<Maybe<never>, never, unknown> {
+		*[Symbol.iterator](): Generator<Maybe<never>, never, unknown> {
 			return (yield this) as never;
 		}
 	}
@@ -818,13 +819,11 @@ export namespace Maybe {
 		}
 
 		/**
-		 * Defining iterable behavior for `Maybe` allows TypeScript to infer
-		 * `Just` types when yielding `Maybe` values in generator comprehensions
-		 * using `yield*`.
-		 *
-		 * @hidden
+		 * Return a `Maybe.Go` generator that yields this `Maybe` and returns
+		 * its value if one is present. This allows `Maybe` values to be yielded
+		 * directly in `Maybe` generator comprehensions using `yield*`.
 		 */
-		*[Symbol.iterator](): Iterator<Maybe<T>, T, unknown> {
+		*[Symbol.iterator](): Generator<Maybe<T>, T, unknown> {
 			return (yield this) as T;
 		}
 	}
@@ -835,12 +834,12 @@ export namespace Maybe {
 	export const nothing = Maybe.Nothing.singleton as Maybe<never>;
 
 	/**
-	 *
+	 * A generator that yields `Maybe` values and returns a result.
 	 */
 	export type Go<TReturn> = Generator<Maybe<unknown>, TReturn, unknown>;
 
 	/**
-	 *
+	 * An async generator that yields `Maybe` values and returns a result.
 	 */
 	export type GoAsync<TReturn> = AsyncGenerator<
 		Maybe<unknown>,

--- a/src/maybe.ts
+++ b/src/maybe.ts
@@ -182,7 +182,7 @@
  * Each `yield*` expression may bind a variable of the present value type of the
  * yielded `Maybe`. Comprehensions should always use `yield*` instead of
  * `yield`. Using `yield*` allows TypeScript to accurately infer the present
- * value type of each yielded `Maybe` when binding the value of a `yield*`
+ * value type of the yielded `Maybe` when binding the value of each `yield*`
  * expression.
  *
  * ### Evaluating comprehensions

--- a/src/maybe.ts
+++ b/src/maybe.ts
@@ -725,6 +725,13 @@ export namespace Maybe {
 		}
 
 		/**
+		 *
+		 */
+		goMap<T, T1>(this: Maybe<T>, f: (val: T) => Go<T1>): Maybe<T1> {
+			return this.flatMap((val) => go(f(val)));
+		}
+
+		/**
 		 * If this `Maybe` is present, apply a function to its value. If the
 		 * result is `null` or `undefined`, return `Nothing`; otherwise, return
 		 * the result in a `Just`. If this `Maybe` is absent, return `Nothing`.

--- a/src/maybe.ts
+++ b/src/maybe.ts
@@ -190,7 +190,7 @@
  * `Maybe.Go` and `Maybe.GoAsync` generators must be evaluated before accessing
  * their results.
  *
- * The `go` function evaluates a `Maybe.Go<T> generator to return a `Maybe<T>`
+ * The `go` function evaluates a `Maybe.Go<T>` generator to return a `Maybe<T>`
  * If any yielded `Maybe` is absent, the generator halts and `go` returns
  * `Nothing`; otherwise, when the generator returns, `go` returns the result in
  * a `Just`.

--- a/src/maybe.ts
+++ b/src/maybe.ts
@@ -276,19 +276,6 @@
  * // input: "0x2A": 18
  * ```
  *
- * We can refactor the `parseEvenInt` function to use a generator comprehension
- * instead:
- *
- * ```ts
- * function parseEvenInt(input: string): Maybe<number> {
- *     return Maybe.go(function* () {
- *         const n = yield* parseInt(input);
- *         const even = yield* guardEven(n);
- *         return even;
- *     });
- * }
- * ```
- *
  * Suppose we want to parse an array of inputs and collect the successful
  * results, or fail on the first parse error. We may write the following:
  *
@@ -313,37 +300,8 @@
  * // inputs ["+42","0x2A"]: [42,42]
  * ```
  *
- * Perhaps we want to collect only distinct even numbers using a Set:
- *
- * ```ts
- * function parseEvenIntsUniq(inputs: string[]): Maybe<Set<number>> {
- *     return Maybe.go(function* () {
- *         const results = new Set<number>();
- *         for (const input of inputs) {
- *             results.add(yield* parseEvenInt(input));
- *         }
- *         return results;
- *     });
- * }
- *
- * [
- *     ["a", "-4"],
- *     ["2", "-7"],
- *     ["+42", "0x2A"],
- * ].forEach((inputs) => {
- *     const result = JSON.stringify(
- *         parseEvenIntsUniq(inputs).map(Array.from).getOr("invalid input"),
- *     );
- *     console.log(`inputs ${JSON.stringify(inputs)}: ${result}`);
- * });
- *
- * // inputs ["a","-4"]: "invalid input"
- * // inputs ["2","-7"]: "invalid input"
- * // inputs ["+42","0x2A"]: [42]
- * ```
- *
- * Or, perhaps we want to associate the original input strings with our
- * successful parses:
+ * Perhaps we want to associate the original input strings with our successful
+ * parses:
  *
  * ```ts
  * function parseEvenIntsKeyed(

--- a/src/maybe.ts
+++ b/src/maybe.ts
@@ -545,20 +545,6 @@ export namespace Maybe {
 	}
 
 	/**
-	 * Construct a function that returns a `Maybe` using a generator
-	 * comprehension.
-	 *
-	 * @remarks
-	 *
-	 * This is the higher-order function variant of `go`.
-	 */
-	export function goFn<TArgs extends unknown[], TReturn>(
-		f: (...args: TArgs) => Generator<Maybe<any>, TReturn, unknown>,
-	): (...args: TArgs) => Maybe<TReturn> {
-		return (...args) => step(f(...args));
-	}
-
-	/**
 	 * Reduce a finite iterable from left to right in the context of `Maybe`.
 	 *
 	 * @remarks
@@ -705,20 +691,6 @@ export namespace Maybe {
 		f: () => AsyncGenerator<Maybe<any>, TReturn, unknown>,
 	): Promise<Maybe<TReturn>> {
 		return stepAsync(f());
-	}
-
-	/**
-	 * Construct a function that returns a `Promise` that fulfills with a
-	 * `Maybe` using an async generator comprehension.
-	 *
-	 * @remarks
-	 *
-	 * This is the higher-order function variant of `goAsync`.
-	 */
-	export function goAsyncFn<TArgs extends unknown[], TReturn>(
-		f: (...args: TArgs) => AsyncGenerator<Maybe<any>, TReturn, unknown>,
-	): (...args: TArgs) => Promise<Maybe<TReturn>> {
-		return (...args) => stepAsync(f(...args));
 	}
 
 	/**

--- a/src/maybe.ts
+++ b/src/maybe.ts
@@ -150,33 +150,56 @@
  * `Maybe`. If a `Maybe` is absent, the computation halts and `Nothing` is
  * returned instead.
  *
- * ### Generator comprehensions
- *
- * Generator comprehensions provide an imperative syntax for chaining together
- * computations that return `Maybe`. Instead of `flatMap`, a generator is used
- * to unwrap present `Maybe` values and apply functions to their values.
- *
- * The `go` function evaluates a generator to return a `Maybe`. Within the
- * generator, `Maybe` values are yielded using the `yield*` keyword. If a
- * yielded `Maybe` is present, its value may be bound to a specified variable.
- * If any yielded `Maybe` is absent, the generator halts and `go` returns
- * `Nothing`; otherwise, when the computation is complete, the generator may
- * return a final result and `go` returns the result in a `Just`.
- *
- * ### Async generator comprehensions
- *
- * Async generator comprehensions provide `async`/`await` syntax to `Maybe`
- * generator comprehensions, allowing promise-like computations that fulfill
- * with `Maybe` to be chained together using the familiar generator syntax.
- *
- * The `goAsync` function evaluates an async generator to return a `Promise`
- * that fulfills with a `Maybe`. The semantics of `yield*` and `return` within
- * async comprehensions are identical to their synchronous counterparts.
- *
  * ## Recovering from `Nothing`
  *
  * The `recover` method evaluates a function to return a fallback `Maybe` if
  * absent, and does nothing if present.
+ *
+ * ## Generator comprehenshions
+ *
+ * Generator comprehensions provide an imperative syntax for chaining together
+ * synchronous or asynchronous computations that return or resolve with `Maybe`
+ * values.
+ *
+ * ### Writing comprehensions
+ *
+ * Synchronus and asynchronous comprehensions are written using `function*` and
+ * `async function*` declarations, respectively.
+ *
+ * Synchronous generator functions should use the `Maybe.Go` type alias as a
+ * return type. A generator function that returns a `Maybe.Go<T>` may `yield*`
+ * zero or more `Maybe<any>` values and must return a result of type `T`.
+ * Synchronous comprehensions may also `yield*` other `Maybe.Go` generators
+ * directly.
+ *
+ * Async generator functions should use the `Maybe.GoAsync` type alias as a
+ * return type. An async generator function that returns a `Maybe.GoAsync<T>`
+ * may `yield*` zero or more `Maybe<any>` values and must return a result of
+ * type `T`. `PromiseLike` values that resolve with `Maybe` should be awaited
+ * before yielding. Async comprehensions may also `yield*` other `Maybe.Go` and
+ * `Maybe.GoAsync` generators directly.
+ *
+ * Each `yield*` expression may bind a variable of the present value type of the
+ * yielded `Maybe`. Comprehensions should always use `yield*` instead of
+ * `yield`. Using `yield*` allows TypeScript to accurately infer the present
+ * value type of each yielded `Maybe` when binding the value of a `yield*`
+ * expression.
+ *
+ * ### Evaluating comprehensions
+ *
+ * `Maybe.Go` and `Maybe.GoAsync` generators must be evaluated before accessing
+ * their results.
+ *
+ * The `go` function evaluates a `Maybe.Go<T> generator to return a `Maybe<T>`
+ * If any yielded `Maybe` is absent, the generator halts and `go` returns
+ * `Nothing`; otherwise, when the generator returns, `go` returns the result in
+ * a `Just`.
+ *
+ * The `goAsync` function evaluates a `Maybe.GoAsync<T>` async generator to
+ * return a `Promise<Maybe<T>>`. If any yielded `Maybe` is absent, the generator
+ * halts and `goAsync` resolves with the `Nothing`; otherwise, when the
+ * generator returns, `goAsync` resolves with the result in a `Just`. Thrown
+ * errors are captured as rejections.
  *
  * ## Collecting into `Maybe`
  *

--- a/src/maybe.ts
+++ b/src/maybe.ts
@@ -451,7 +451,7 @@ export namespace Maybe {
 	}
 
 	/**
-	 * Interpret a `Maybe.Go` generator to return a `Maybe.`
+	 * Evaluate a `Maybe.Go` generator to return a `Maybe.`
 	 */
 	export function go<TReturn>(gen: Go<TReturn>): Maybe<TReturn> {
 		let nxt = gen.next();
@@ -571,7 +571,7 @@ export namespace Maybe {
 	}
 
 	/**
-	 * Interpret a `Maybe.GoAsync` async generator to return a `Promise` that
+	 * Evaluate a `Maybe.GoAsync` async generator to return a `Promise` that
 	 * resolves with a `Maybe`.
 	 */
 	export async function goAsync<TReturn>(
@@ -708,7 +708,7 @@ export namespace Maybe {
 
 		/**
 		 * If this `Maybe` is present, apply a generator comprehension function
-		 * to its value and interpret the `Maybe.Go` generator to return another
+		 * to its value and evaluate the `Maybe.Go` generator to return another
 		 * `Maybe`; otherwise, return `Nothing`.
 		 */
 		goMap<T, T1>(this: Maybe<T>, f: (val: T) => Go<T1>): Maybe<T1> {

--- a/src/pair.test.ts
+++ b/src/pair.test.ts
@@ -22,7 +22,6 @@ import {
 	expectLawfulEq,
 	expectLawfulOrd,
 	expectLawfulSemigroup,
-	tuple,
 } from "./_test/utils.js";
 import { cmb } from "./cmb.js";
 import { cmp, eq } from "./cmp.js";
@@ -121,7 +120,10 @@ describe("Pair", () => {
 
 	describe("#unwrap", () => {
 		it("applies the function to the first value and the second value", () => {
-			const result = new Pair<1, 2>(1, 2).unwrap(tuple);
+			const result = new Pair<1, 2>(1, 2).unwrap((fst, snd): [1, 2] => [
+				fst,
+				snd,
+			]);
 			expect(result).to.deep.equal([1, 2]);
 		});
 	});

--- a/src/validation.test.ts
+++ b/src/validation.test.ts
@@ -23,7 +23,6 @@ import {
 	expectLawfulEq,
 	expectLawfulOrd,
 	expectLawfulSemigroup,
-	tuple,
 } from "./_test/utils.js";
 import { cmb } from "./cmb.js";
 import { Ordering, cmp, eq } from "./cmp.js";
@@ -92,7 +91,10 @@ describe("Validation", () => {
 
 	describe("lift", () => {
 		it("lifts the function into the context of Validation", () => {
-			const vdn = Validation.lift(tuple<[2, 4]>)(
+			function f<A, B>(lhs: A, rhs: B): [A, B] {
+				return [lhs, rhs];
+			}
+			const vdn = Validation.lift(f<2, 4>)(
 				Validation.ok(2),
 				Validation.ok(4),
 			);
@@ -246,7 +248,7 @@ describe("Validation", () => {
 		it("combines the failures if both variants are Err", () => {
 			const vdn = Validation.err<Str, 2>(new Str("a")).zipWith(
 				Validation.err<Str, 4>(new Str("b")),
-				tuple,
+				(lhs, rhs): [2, 4] => [lhs, rhs],
 			);
 			expect(vdn).to.deep.equal(Validation.err(new Str("ab")));
 		});
@@ -254,7 +256,7 @@ describe("Validation", () => {
 		it("returns the first Err if the second variant is Ok", () => {
 			const vdn = Validation.err<Str, 2>(new Str("a")).zipWith(
 				Validation.ok<4, Str>(4),
-				tuple,
+				(lhs, rhs): [2, 4] => [lhs, rhs],
 			);
 			expect(vdn).to.deep.equal(Validation.err(new Str("a")));
 		});
@@ -262,7 +264,7 @@ describe("Validation", () => {
 		it("returns the second Err if the first variant is Ok", () => {
 			const vdn = Validation.ok<2, Str>(2).zipWith(
 				Validation.err<Str, 4>(new Str("b")),
-				tuple,
+				(lhs, rhs): [2, 4] => [lhs, rhs],
 			);
 			expect(vdn).to.deep.equal(Validation.err(new Str("b")));
 		});
@@ -270,7 +272,7 @@ describe("Validation", () => {
 		it("applies the function to the successes if both variants are Ok", () => {
 			const vdn = Validation.ok<2, Str>(2).zipWith(
 				Validation.ok<4, Str>(4),
-				tuple,
+				(lhs, rhs): [2, 4] => [lhs, rhs],
 			);
 			expect(vdn).to.deep.equal(Validation.ok([2, 4]));
 		});


### PR DESCRIPTION
This PR introduces a new method of writing and interpreting generator comprehensions that better leverages generator functions as first-class constructs. Generator comprehensions may now be written as plain generator or async generator functions. The functions should make use of the `Go` and `GoAsync` return types to indicate that they are a generator comprehension. The `go` and `goAsync` functions will now interpret a generator or an async generator, instead of accepting a generator or async generator function.

This updated syntax has the following advantages:

- Generator comprehensions can be more easily created, reused, and composed.
- Generator comprehensions can now `yield*` other generators directly.
- Return types are now explicit and the type inference of `go` and `goAsync` has been simplified.

This PR also introduces the `goMap` method, a `flatMap`-like concept that accepts a generator function continuation. This allows composition with synchronous generator comprehensions similar to what can be achieved with `flatMap`.