### PR TITLE
Rename the `collect` combinators to `all`.

### DIFF
--- a/src/either.test.ts
+++ b/src/either.test.ts
@@ -131,9 +131,9 @@ describe("Either", () => {
 		});
 	});
 
-	describe("collect", () => {
+	describe("all", () => {
 		it("turns the array or the tuple literal of Either elements inside out", () => {
-			const either = Either.collect([
+			const either = Either.all([
 				Either.right<2, 1>(2),
 				Either.right<4, 3>(4),
 			]);

--- a/src/either.ts
+++ b/src/either.ts
@@ -197,8 +197,8 @@
  * container and returned as a success. If any element fails, the failed
  * `Either` is returned instead.
  *
- * -   `collect` turns an array or a tuple literal of `Either` elements inside
- *     out. For example:
+ * -   `all` turns an array or a tuple literal of `Either` elements inside out.
+ *     For example:
  *     -   `Either<E, T>[]` becomes `Either<E, T[]>`
  *     -   `[Either<E, T1>, Either<E, T2>]` becomes `Either<E, [T1, T2]>`
  * -   `gather` turns a record or an object literal of `Either` elements inside
@@ -296,7 +296,7 @@
  *
  * ```ts
  * function parseEvenInts(inputs: string[]): Either<string, number[]> {
- *     return Either.collect(inputs.map(parseEvenInt));
+ *     return Either.all(inputs.map(parseEvenInt));
  * }
  *
  * [
@@ -472,7 +472,7 @@ export namespace Either {
 	 * -   `Either<E, T>[]` becomes `Either<E, T[]>`
 	 * -   `[Either<E, T1>, Either<E, T2>]` becomes `Either<E, [T1, T2]>`
 	 */
-	export function collect<TEithers extends readonly Either<any, any>[] | []>(
+	export function all<TEithers extends readonly Either<any, any>[] | []>(
 		eithers: TEithers,
 	): Either<
 		LeftT<TEithers[number]>,
@@ -539,7 +539,7 @@ export namespace Either {
 		...eithers: TEithers
 	) => Either<LeftT<TEithers[number]>, T> {
 		return (...eithers) =>
-			collect(eithers).map((args) => f(...(args as TArgs)));
+			all(eithers).map((args) => f(...(args as TArgs)));
 	}
 
 	/**

--- a/src/eval.test.ts
+++ b/src/eval.test.ts
@@ -91,9 +91,9 @@ describe("Eval", () => {
 		});
 	});
 
-	describe("collect", () => {
+	describe("all", () => {
 		it("turns the array or the tuple literal of Eval elements inside out", () => {
-			const ev = Eval.collect([Eval.now<1>(1), Eval.now<2>(2)]);
+			const ev = Eval.all([Eval.now<1>(1), Eval.now<2>(2)]);
 			const outcome = ev.run();
 			expect(outcome).to.deep.equal([1, 2]);
 		});

--- a/src/eval.ts
+++ b/src/eval.ts
@@ -110,8 +110,8 @@
  * These static methods turn a container of `Eval` elements "inside out" into an
  * `Eval` that contains an equivalent container of outcomes:
  *
- * -   `collect` turns an array or a tuple literal of `Eval` elements inside
- *     out. For example:
+ * -   `all` turns an array or a tuple literal of `Eval` elements inside out.
+ *     For example:
  *     -   `Eval<T>[]` becomes `Eval<T[]>`
  *     -   `[Eval<T1>, Eval<T2>]` becomes `Eval<[T1, T2]>`
  * -   `gather` turns a record or an object literal of `Eval` elements inside
@@ -223,7 +223,7 @@
  * type Traversals<T> = [in: T[], pre: T[], post: T[]];
  *
  * function traversals<T>(tree: Tree<T>): Eval<Traversals<T>> {
- *     return Eval.collect([
+ *     return Eval.all([
  *         inOrder(tree),
  *         preOrder(tree),
  *         postOrder(tree),
@@ -355,7 +355,7 @@ export class Eval<out T> {
 	 * -   `Eval<T>[]` becomes `Eval<T[]>`
 	 * -   `[Eval<T1>, Eval<T2>]` becomes `Eval<[T1, T2]>`
 	 */
-	static collect<TEvals extends readonly Eval<any>[] | []>(
+	static all<TEvals extends readonly Eval<any>[] | []>(
 		evals: TEvals,
 	): Eval<{ -readonly [K in keyof TEvals]: Eval.ResultT<TEvals[K]> }> {
 		return Eval.go(
@@ -410,7 +410,7 @@ export class Eval<out T> {
 	static lift<TArgs extends unknown[], T>(
 		f: (...args: TArgs) => T,
 	): (...evals: { [K in keyof TArgs]: Eval<TArgs[K]> }) => Eval<T> {
-		return (...evals) => Eval.collect(evals).map((args) => f(...args));
+		return (...evals) => Eval.all(evals).map((args) => f(...args));
 	}
 
 	/**

--- a/src/ior.test.ts
+++ b/src/ior.test.ts
@@ -223,9 +223,9 @@ describe("Ior", () => {
 		});
 	});
 
-	describe("collect", () => {
+	describe("all", () => {
 		it("turns the array or the tuple literal of Ior elements inside out", () => {
-			const ior = Ior.collect([
+			const ior = Ior.all([
 				Ior.both<Str, 2>(new Str("a"), 2),
 				Ior.both<Str, 4>(new Str("b"), 4),
 			]);

--- a/src/ior.ts
+++ b/src/ior.ts
@@ -214,8 +214,8 @@
  * `Left`, the collection halts and the left-hand value is combined with any
  * existing left-hand value, and the result is returned in a `Left`.
  *
- * -   `collect` turns an array or a tuple literal of `Ior` elements inside out.
- *     For example:
+ * -   `all` turns an array or a tuple literal of `Ior` elements inside out. For
+ *     example:
  *     -   `Ior<A, B>[]` becomes `Ior<A, B[]>`
  *     -   `[Ior<A, B1>, Ior<A, B2>]` becomes `Ior<A, [B1, B2]>`
  * -   `gather` turns a record or an object literal of `Ior` elements inside
@@ -353,7 +353,7 @@
  *
  * ```ts
  * function parseEvenInts(inputs: string[]): Ior<Log, number[]> {
- *     return Ior.collect(inputs.map(parseEvenInt));
+ *     return Ior.all(inputs.map(parseEvenInt));
  * }
  *
  * [
@@ -586,9 +586,7 @@ export namespace Ior {
 	 * -   `Ior<A, B>[]` becomes `Ior<A, B[]>`
 	 * -   `[Ior<A, B1>, Ior<A, B2>]` becomes `Ior<A, [B1, B2]>`
 	 */
-	export function collect<
-		TIors extends readonly Ior<Semigroup<any>, any>[] | [],
-	>(
+	export function all<TIors extends readonly Ior<Semigroup<any>, any>[] | []>(
 		iors: TIors,
 	): Ior<
 		LeftT<TIors[number]>,
@@ -660,7 +658,7 @@ export namespace Ior {
 		...iors: { [K in keyof TArgs]: Ior<A, TArgs[K]> }
 	) => Ior<A, T> {
 		return (...iors) =>
-			collect(iors).map((args) => f(...(args as TArgs))) as Ior<any, T>;
+			all(iors).map((args) => f(...(args as TArgs))) as Ior<any, T>;
 	}
 
 	/**

--- a/src/maybe.test.ts
+++ b/src/maybe.test.ts
@@ -165,9 +165,9 @@ describe("Maybe", () => {
 		});
 	});
 
-	describe("collect", () => {
+	describe("all", () => {
 		it("turns the array or the tuple literal of Maybe elements inside out", () => {
-			const maybe = Maybe.collect([Maybe.just<1>(1), Maybe.just<2>(2)]);
+			const maybe = Maybe.all([Maybe.just<1>(1), Maybe.just<2>(2)]);
 			expect(maybe).to.deep.equal(Maybe.just([1, 2]));
 		});
 	});

--- a/src/maybe.ts
+++ b/src/maybe.ts
@@ -208,8 +208,8 @@
  * container and returned in a `Just`. If any element is absent, `Nothing` is
  * returned instead.
  *
- * -   `collect` turns an array or a tuple literal of `Maybe` elements inside
- *     out. For example:
+ * -   `all` turns an array or a tuple literal of `Maybe` elements inside out.
+ *     For example:
  *     -   `Maybe<T>[]` becomes `Maybe<T[]>`
  *     -   `[Maybe<T1>, Maybe<T2>]` becomes `Maybe<[T1, T2]>`
  * -   `gather` turns a record or an object literal of `Maybe` elements inside
@@ -304,7 +304,7 @@
  *
  * ```ts
  * function parseEvenInts(inputs: string[]): Maybe<number[]> {
- *     return Maybe.collect(inputs.map(parseEvenInt));
+ *     return Maybe.all(inputs.map(parseEvenInt));
  * }
  *
  * [
@@ -510,7 +510,7 @@ export namespace Maybe {
 	 * -   `Maybe<T>[]` becomes `Maybe<T[]>`
 	 * -   `[Maybe<T1>, Maybe<T2>]` becomes `Maybe<[T1, T2]>`
 	 */
-	export function collect<TMaybes extends readonly Maybe<any>[] | []>(
+	export function all<TMaybes extends readonly Maybe<any>[] | []>(
 		maybes: TMaybes,
 	): Maybe<{ -readonly [K in keyof TMaybes]: JustT<TMaybes[K]> }> {
 		return go(
@@ -567,7 +567,7 @@ export namespace Maybe {
 	export function lift<TArgs extends unknown[], T>(
 		f: (...args: TArgs) => T,
 	): (...maybes: { [K in keyof TArgs]: Maybe<TArgs[K]> }) => Maybe<T> {
-		return (...maybes) => collect(maybes).map((args) => f(...args));
+		return (...maybes) => all(maybes).map((args) => f(...args));
 	}
 
 	/**

--- a/src/validation.test.ts
+++ b/src/validation.test.ts
@@ -69,9 +69,9 @@ describe("Validation", () => {
 		});
 	});
 
-	describe("collect", () => {
+	describe("all", () => {
 		it("turns the array or the tuple literal of Validation elements inside out", () => {
-			const vdn = Validation.collect([
+			const vdn = Validation.all([
 				Validation.ok<2, Str>(2),
 				Validation.ok<4, Str>(4),
 			]);

--- a/src/validation.ts
+++ b/src/validation.ts
@@ -137,8 +137,8 @@
  * container and returned as a success. If any element fails, the collection
  * halts and failures begin accumulating instead.
  *
- * -   `collect` turns an array or a tuple literal of `Validation` elements
- *     inside out. For example:
+ * -   `all` turns an array or a tuple literal of `Validation` elements inside
+ *     out. For example:
  *     -   `Validation<E, T>[]` becomes `Validation<E, T[]>`
  *     -   `[Validation<E, T1>, Validation<E, T2>]` becomes `Validation<E, [T1,
  *         T2]>`
@@ -349,7 +349,7 @@
  * function requireLowercaseElems(
  *     inputs: string[]
  * ): Validation<List<string>, string[]> {
- *     return Validation.collect(inputs.map(requireLowercase));
+ *     return Validation.all(inputs.map(requireLowercase));
  * }
  *
  * [
@@ -430,7 +430,7 @@ export namespace Validation {
 	 * -   `[Validation<E, T1>, Validation<E, T2>]` becomes `Validation<E, [T1,
 	 *     T2]>`
 	 */
-	export function collect<
+	export function all<
 		TVdns extends readonly Validation<Semigroup<any>, any>[] | [],
 	>(
 		vdns: TVdns,
@@ -500,7 +500,7 @@ export namespace Validation {
 		...vdns: { [K in keyof TArgs]: Validation<E, TArgs[K]> }
 	) => Validation<E, T> {
 		return (...vdns) =>
-			collect(vdns).map((args) => f(...(args as TArgs))) as Validation<
+			all(vdns).map((args) => f(...(args as TArgs))) as Validation<
 				any,
 				T
 			>;


### PR DESCRIPTION
This brings them more in-line with existing JavaScript conventions, e.g. `Promise.all`.