### PR TITLE
Rename the `gather` combinators to `allProps`

### DIFF
--- a/src/either.test.ts
+++ b/src/either.test.ts
@@ -141,9 +141,9 @@ describe("Either", () => {
 		});
 	});
 
-	describe("gather", () => {
+	describe("allProps", () => {
 		it("turns the record or the object literal of Either elements inside out", () => {
-			const either = Either.gather({
+			const either = Either.allProps({
 				x: Either.right<2, 1>(2),
 				y: Either.right<4, 3>(4),
 			});

--- a/src/either.ts
+++ b/src/either.ts
@@ -201,8 +201,8 @@
  *     For example:
  *     -   `Either<E, T>[]` becomes `Either<E, T[]>`
  *     -   `[Either<E, T1>, Either<E, T2>]` becomes `Either<E, [T1, T2]>`
- * -   `gather` turns a record or an object literal of `Either` elements inside
- *     out. For example:
+ * -   `allProps` turns a string-keyed record or object literal of `Either`
+ *     elements inside out. For example:
  *     -   `Record<string, Either<E, T>>` becomes `Either<E, Record<string, T>>`
  *     -   `{ x: Either<E, T1>, y: Either<E, T2> }` becomes `Either<E, { x: T1,
  *         y: T2 }>`
@@ -320,7 +320,7 @@
  * function parseEvenIntsKeyed(
  *     inputs: string[],
  * ): Either<string, Record<string, number>> {
- *     return Either.gather(
+ *     return Either.allProps(
  *         Object.fromEntries(
  *             inputs.map((input) => [input, parseEvenInt(input)] as const),
  *         ),
@@ -490,14 +490,15 @@ export namespace Either {
 	}
 
 	/**
-	 * Turn a record or an object literal of `Either` elements "inside out".
+	 * Turn a string-keyed record or object literal of `Either` elements "inside
+	 * out".
 	 *
 	 * @remarks
 	 *
-	 * Evaluate the `Either` elements in a record or an object literal. If they
-	 * all succeed, collect their successes in a record or an object literal,
-	 * respectively, and succeed with the result; otherwise, return the first
-	 * failed `Either`.
+	 * Enumerate an object's own enumerable, string-keyed property key-`Either`
+	 * pairs. If all `Either` values succeed, succeed with an object that
+	 * contains the keys and their associated successes; otherwise, return the
+	 * first failed `Either`.
 	 *
 	 * For example:
 	 *
@@ -505,7 +506,7 @@ export namespace Either {
 	 * -   `{ x: Either<E, T1>, y: Either<E, T2> }` becomes `Either<E, { x: T1,
 	 *     y: T2 }>`
 	 */
-	export function gather<TEithers extends Record<any, Either<any, any>>>(
+	export function allProps<TEithers extends Record<string, Either<any, any>>>(
 		eithers: TEithers,
 	): Either<
 		LeftT<TEithers[keyof TEithers]>,
@@ -513,7 +514,7 @@ export namespace Either {
 	> {
 		return go(
 			(function* () {
-				const results: Record<any, any> = {};
+				const results: Record<string, any> = {};
 				for (const [key, either] of Object.entries(eithers)) {
 					results[key] = yield* either;
 				}

--- a/src/eval.test.ts
+++ b/src/eval.test.ts
@@ -99,9 +99,9 @@ describe("Eval", () => {
 		});
 	});
 
-	describe("gather", () => {
+	describe("allProps", () => {
 		it("turns the record or the object literal of Eval elements inside out", () => {
-			const ev = Eval.gather({
+			const ev = Eval.allProps({
 				x: Eval.now<1>(1),
 				y: Eval.now<2>(2),
 			});

--- a/src/eval.ts
+++ b/src/eval.ts
@@ -114,8 +114,8 @@
  *     For example:
  *     -   `Eval<T>[]` becomes `Eval<T[]>`
  *     -   `[Eval<T1>, Eval<T2>]` becomes `Eval<[T1, T2]>`
- * -   `gather` turns a record or an object literal of `Eval` elements inside
- *     out. For example:
+ * -   `allProps` turns a string-keyed record or object literal of `Eval`
+ *     elements inside out. For example:
  *     -   `Record<string, Eval<T>>` becomes `Eval<Record<string, T>>`
  *     -   `{ x: Eval<T1>, y: Eval<T2> }` becomes `Eval<{ x: T1, y: T2 }>`
  *
@@ -246,7 +246,7 @@
  * }
  *
  * function traversalsKeyed<T>(tree: Tree<T>): Eval<TraversalsObj<T>> {
- *     return Eval.gather({
+ *     return Eval.allProps({
  *         in: inOrder(tree),
  *         pre: preOrder(tree),
  *         post: postOrder(tree),
@@ -370,25 +370,26 @@ export class Eval<out T> {
 	}
 
 	/**
-	 * Turn a record or an object literal of `Eval` elements "inside out".
+	 * Turn a string-keyed record or object literal of `Eval` elements "inside
+	 * out".
 	 *
 	 * @remarks
 	 *
-	 * Evaluate the `Eval` elements in a record or an object literal. Collect
-	 * their outcomes in a record or an object literal, respectively, and return
-	 * the result in an `Eval`.
+	 * Enumerate an object's own enumerable, string-keyed property key-`Eval`
+	 * pairs. Return an `Eval` that contains an object of the keys and their
+	 * associated outcomes.
 	 *
 	 * For example:
 	 *
 	 * -   `Record<string, Eval<T>>` becomes `Eval<Record<string, T>>`
 	 * -   `{ x: Eval<T1>, y: Eval<T2> }` becomes `Eval<{ x: T1, y: T2 }>`
 	 */
-	static gather<TEvals extends Record<any, Eval<any>>>(
+	static allProps<TEvals extends Record<string, Eval<any>>>(
 		evals: TEvals,
 	): Eval<{ -readonly [K in keyof TEvals]: Eval.ResultT<TEvals[K]> }> {
 		return Eval.go(
 			(function* () {
-				const results: Record<any, any> = {};
+				const results: Record<string, any> = {};
 				for (const [key, ev] of Object.entries(evals)) {
 					results[key] = yield* ev;
 				}

--- a/src/ior.test.ts
+++ b/src/ior.test.ts
@@ -233,9 +233,9 @@ describe("Ior", () => {
 		});
 	});
 
-	describe("gather", () => {
+	describe("allProps", () => {
 		it("turns the record or the object literal of Ior elements inside out", () => {
-			const ior = Ior.gather({
+			const ior = Ior.allProps({
 				x: Ior.both<Str, 2>(new Str("a"), 2),
 				y: Ior.both<Str, 4>(new Str("b"), 4),
 			});

--- a/src/ior.ts
+++ b/src/ior.ts
@@ -218,8 +218,8 @@
  *     example:
  *     -   `Ior<A, B>[]` becomes `Ior<A, B[]>`
  *     -   `[Ior<A, B1>, Ior<A, B2>]` becomes `Ior<A, [B1, B2]>`
- * -   `gather` turns a record or an object literal of `Ior` elements inside
- *     out. For example:
+ * -   `allProps` turns a string-keyed record or object literal of `Ior`
+ *     elements inside out. For example:
  *     -   `Record<string, Ior<A, B>>` becomes `Ior<A, Record<string, B>>`
  *     -   `{ x: Ior<A, B1>, y: Ior<A, B2> }` becomes `Ior<A, { x: B1, y: B2 }>`
  *
@@ -380,7 +380,7 @@
  * function parseEvenIntsKeyed(
  *     inputs: string[],
  * ): Ior<Log, Record<string, number>> {
- *     return Ior.gather(
+ *     return Ior.allProps(
  *         Object.fromEntries(
  *             inputs.map((input) => [input, parseEvenInt(input)] as const),
  *         ),
@@ -593,7 +593,7 @@ export namespace Ior {
 		{ -readonly [K in keyof TIors]: RightT<TIors[K]> }
 	> {
 		return go(
-			(function* (): Ior.Go<any, any> {
+			(function* (): Go<any, any> {
 				const results = new Array(iors.length);
 				for (const [idx, ior] of iors.entries()) {
 					results[idx] = yield* ior;
@@ -604,32 +604,35 @@ export namespace Ior {
 	}
 
 	/**
-	 * Turn a record or an object literal of `Ior` elements "inside out".
+	 * Turn a string-keyed record or object literal of `Ior` elements "inside
+	 * out".
 	 *
 	 * @remarks
 	 *
-	 * Evaluate the `Ior` elements in a record or an object literal. If they all
-	 * have right-hand values, collect the values in a record or an object
-	 * literal, tuple literal, respectively, and return the result as a
-	 * right-hand value. Accumulate the left-hand values of `Both` variants
-	 * using their behavior as a semigroup. If any element is a `Left`, halt the
-	 * collection and combine the left-hand value with any existing left-hand
-	 * value, and return the result in a `Left`.
+	 * Enumerate an object's own enumerable, string-keyed property key-`Ior`
+	 * pairs. If all `Ior` values have right-hand values, return an object as a
+	 * right-hand value that contains the keys and their associated right-hand
+	 * values. Accumulate the left-hand values of `Both` variants using their
+	 * behavior as a semigroup. If any value is a `Left`, halt the collection
+	 * and combine the left-hand value with any existing left-hand value, and
+	 * return the result in a `Left`.
 	 *
 	 * For example:
 	 *
 	 * -   `Record<string, Ior<A, B>>` becomes `Ior<A, Record<string, B>>`
 	 * -   `{ x: Ior<A, B1>, y: Ior<A, B2> }` becomes `Ior<A, { x: B1, y: B2 }>`
 	 */
-	export function gather<TIors extends Record<any, Ior<Semigroup<any>, any>>>(
+	export function allProps<
+		TIors extends Record<string, Ior<Semigroup<any>, any>>,
+	>(
 		iors: TIors,
 	): Ior<
 		LeftT<TIors[keyof TIors]>,
 		{ -readonly [K in keyof TIors]: RightT<TIors[K]> }
 	> {
 		return go(
-			(function* (): Ior.Go<any, any> {
-				const results: Record<any, any> = {};
+			(function* (): Go<any, any> {
+				const results: Record<string, any> = {};
 				for (const [key, ior] of Object.entries(iors)) {
 					results[key] = yield* ior;
 				}

--- a/src/maybe.test.ts
+++ b/src/maybe.test.ts
@@ -172,9 +172,9 @@ describe("Maybe", () => {
 		});
 	});
 
-	describe("gather", () => {
+	describe("allProps", () => {
 		it("turns the record or the object literal of Maybe elements inside out", () => {
-			const maybe = Maybe.gather({
+			const maybe = Maybe.allProps({
 				x: Maybe.just<1>(1),
 				y: Maybe.just<2>(2),
 			});

--- a/src/maybe.ts
+++ b/src/maybe.ts
@@ -212,8 +212,8 @@
  *     For example:
  *     -   `Maybe<T>[]` becomes `Maybe<T[]>`
  *     -   `[Maybe<T1>, Maybe<T2>]` becomes `Maybe<[T1, T2]>`
- * -   `gather` turns a record or an object literal of `Maybe` elements inside
- *     out. For example:
+ * -   `allProps` turns a string-keyed record or object literal of `Maybe`
+ *     elements inside out. For example:
  *     -   `Record<string, Maybe<T>>` becomes `Maybe<Record<string, T>>`
  *     -   `{ x: Maybe<T1>, y: Maybe<T2> }` becomes `Maybe<{ x: T1, y: T2 }>`
  *
@@ -330,7 +330,7 @@
  * function parseEvenIntsKeyed(
  *     inputs: string[],
  * ): Maybe<Record<string, number>> {
- *     return Maybe.gather(
+ *     return Maybe.allProps(
  *         Object.fromEntries(
  *             inputs.map((input) => [input, parseEvenInt(input)] as const),
  *         ),
@@ -525,26 +525,27 @@ export namespace Maybe {
 	}
 
 	/**
-	 * Turn a record or an object literal of `Maybe` elements "inside out".
+	 * Turn a string-keyed record or object literal of `Maybe` elements "inside
+	 * out".
 	 *
 	 * @remarks
 	 *
-	 * Evaluate the `Maybe` elements in a record or an object literal. If they
-	 * are all present, collect their values in a record or an object literal,
-	 * respectively, and return the result in a `Just`; otherwise, return
-	 * `Nothing`.
+	 * Enumerate an object's own enumerable, string-keyed property key-`Maybe`
+	 * pairs. If all `Maybe` values are present, return a `Just` that contains
+	 * an object of the keys and their associated present values; otherwise,
+	 * return `Nothing`.
 	 *
 	 * For example:
 	 *
 	 * -   `Record<string, Maybe<T>>` becomes `Maybe<Record<string, T>>`
 	 * -   `{ x: Maybe<T1>, y: Maybe<T2> }` becomes `Maybe<{ x: T1, y: T2 }>`
 	 */
-	export function gather<TMaybes extends Record<any, Maybe<any>>>(
+	export function allProps<TMaybes extends Record<string, Maybe<any>>>(
 		maybes: TMaybes,
 	): Maybe<{ -readonly [K in keyof TMaybes]: JustT<TMaybes[K]> }> {
 		return go(
 			(function* () {
-				const results: Record<any, any> = {};
+				const results: Record<string, any> = {};
 				for (const [key, maybe] of Object.entries(maybes)) {
 					results[key] = yield* maybe;
 				}

--- a/src/validation.test.ts
+++ b/src/validation.test.ts
@@ -79,9 +79,9 @@ describe("Validation", () => {
 		});
 	});
 
-	describe("gather", () => {
+	describe("allProps", () => {
 		it("turns the record or the object literal of Validation elements inside out", () => {
-			const vdn = Validation.gather({
+			const vdn = Validation.allProps({
 				x: Validation.ok<2, Str>(2),
 				y: Validation.ok<4, Str>(4),
 			});

--- a/src/validation.ts
+++ b/src/validation.ts
@@ -142,8 +142,8 @@
  *     -   `Validation<E, T>[]` becomes `Validation<E, T[]>`
  *     -   `[Validation<E, T1>, Validation<E, T2>]` becomes `Validation<E, [T1,
  *         T2]>`
- * -   `gather` turns a record or an object literal of `Validation` elements
- *     inside out. For example:
+ * -   `allProps` turns a string-keyed record or object literal of `Validation`
+ *     elements inside out. For example:
  *     -   `Record<string, Validation<E, T>>` becomes `Validation<E,
  *         Record<string, T>>`
  *     -   `{ x: Validation<E, T1>, y: Validation<E, T2> }` becomes
@@ -284,7 +284,7 @@
  *     rawName: string,
  *     rawAge: number,
  * ): Validation<List<string>, Person> {
- *     return Validation.gather({
+ *     return Validation.allProps({
  *         name: validateName(rawName),
  *         age: validateAge(rawAge),
  *     });
@@ -449,14 +449,15 @@ export namespace Validation {
 	}
 
 	/**
-	 * Turn a record or an object literal of `Validation` elements "inside out".
+	 * Turn a string-keyed record or object literal of `Validation` elements
+	 * "inside out".
 	 *
 	 * @remarks
 	 *
-	 * Evaluate the `Validation` elements in a record or an object literal. If
-	 * they all succeed, collect their successes in a record or an object
-	 * literal, respectively, and succeed with the result; otherwise, begin
-	 * accumulating failures on the first failed `Validation`.
+	 * Enumerate an object's own enumerable, string-keyed property
+	 * key-`Validation` pairs. If all `Validation` values succeed, succeed with
+	 * an object that contains the keys and their associated successes;
+	 * otherwise, begin accumulating failures on the first failed `Validation`.
 	 *
 	 * For example:
 	 *
@@ -465,7 +466,7 @@ export namespace Validation {
 	 * -   `{ x: Validation<E, T1>, y: Validation<E, T2> }` becomes
 	 *     `Validation<E, { x: T1, y: T2 }>`
 	 */
-	export function gather<
+	export function allProps<
 		TVdns extends Record<string, Validation<Semigroup<any>, any>>,
 	>(
 		vdns: TVdns,


### PR DESCRIPTION
This brings them more in-line with the existing `all` combinators.