### PR TITLE
Tidy up the unit tests

### DIFF
--- a/src/_test/utils.test.ts
+++ b/src/_test/utils.test.ts
@@ -30,11 +30,10 @@ import {
 describe("Num", () => {
 	describe("#[Eq.eq]", () => {
 		it("compares the values strictly", () => {
-			fc.assert(
-				fc.property(arbNum(), arbNum(), (x, y) => {
-					expect(eq(x, y)).to.equal(x.val === y.val);
-				}),
-			);
+			const property = fc.property(arbNum(), arbNum(), (x, y) => {
+				expect(eq(x, y)).to.equal(x.val === y.val);
+			});
+			fc.assert(property);
 		});
 
 		it("implements a lawful equivalence relation", () => {
@@ -44,13 +43,10 @@ describe("Num", () => {
 
 	describe("#[Ord.cmp]", () => {
 		it("compares the values as ordered from least to greatest", () => {
-			fc.assert(
-				fc.property(arbNum(), arbNum(), (x, y) => {
-					expect(cmp(x, y)).to.equal(
-						Ordering.fromNumber(x.val - y.val),
-					);
-				}),
-			);
+			const property = fc.property(arbNum(), arbNum(), (x, y) => {
+				expect(cmp(x, y)).to.equal(Ordering.fromNumber(x.val - y.val));
+			});
+			fc.assert(property);
 		});
 
 		it("implements a lawful total order", () => {
@@ -62,11 +58,10 @@ describe("Num", () => {
 describe("Str", () => {
 	describe("#[Eq.eq]", () => {
 		it("compares the values strictly", () => {
-			fc.assert(
-				fc.property(arbStr(), arbStr(), (x, y) => {
-					expect(eq(x, y)).to.equal(x.val === y.val);
-				}),
-			);
+			const property = fc.property(arbStr(), arbStr(), (x, y) => {
+				expect(eq(x, y)).to.equal(x.val === y.val);
+			});
+			fc.assert(property);
 		});
 
 		it("implements a lawful equivalence relation", () => {
@@ -76,11 +71,10 @@ describe("Str", () => {
 
 	describe("#[Semigroup.cmb]", () => {
 		it("concatenates the values", () => {
-			fc.assert(
-				fc.property(arbStr(), arbStr(), (x, y) => {
-					expect(cmb(x, y)).to.deep.equal(new Str(x.val + y.val));
-				}),
-			);
+			const property = fc.property(arbStr(), arbStr(), (x, y) => {
+				expect(cmb(x, y)).to.deep.equal(new Str(x.val + y.val));
+			});
+			fc.assert(property);
 		});
 
 		it("implements a lawful semigroup", () => {

--- a/src/_test/utils.ts
+++ b/src/_test/utils.ts
@@ -52,69 +52,60 @@ export function arbStr(): fc.Arbitrary<Str> {
 }
 
 export function expectLawfulEq<T extends Eq<T>>(arb: fc.Arbitrary<T>): void {
-	fc.assert(
-		fc.property(arb, (val) => {
-			expect(eq(val, val), "reflexivity").to.be.true;
-		}),
-	);
+	const reflexivity = fc.property(arb, (val) => {
+		expect(eq(val, val), "reflexivity").to.be.true;
+	});
 
-	fc.assert(
-		fc.property(arb, arb, (lhs, rhs) => {
-			expect(eq(lhs, rhs), "symmetry").to.equal(eq(rhs, lhs));
-		}),
-	);
+	const symmetry = fc.property(arb, arb, (lhs, rhs) => {
+		expect(eq(lhs, rhs), "symmetry").to.equal(eq(rhs, lhs));
+	});
 
-	fc.assert(
-		fc.property(arb, arb, arb, (first, second, third) => {
-			if (eq(first, second) && eq(second, third)) {
-				expect(eq(first, third), "transitivity").to.be.true;
-			}
-		}),
-	);
+	const transitivity = fc.property(arb, arb, arb, (first, second, third) => {
+		if (eq(first, second) && eq(second, third)) {
+			expect(eq(first, third), "transitivity").to.be.true;
+		}
+	});
+
+	fc.assert(reflexivity);
+	fc.assert(symmetry);
+	fc.assert(transitivity);
 }
 
 export function expectLawfulOrd<T extends Ord<T>>(arb: fc.Arbitrary<T>): void {
-	fc.assert(
-		fc.property(arb, (val) => {
-			expect(le(val, val), "reflexivity").to.be.true;
-		}),
-	);
+	const reflexivity = fc.property(arb, (val) => {
+		expect(le(val, val), "reflexivity").to.be.true;
+	});
 
-	fc.assert(
-		fc.property(arb, arb, (lhs, rhs) => {
-			expect(le(lhs, rhs) && le(rhs, lhs), "antisymmetry").to.equal(
-				eq(lhs, rhs),
-			);
-		}),
-	);
+	const antisymmetry = fc.property(arb, arb, (lhs, rhs) => {
+		expect(le(lhs, rhs) && le(rhs, lhs), "antisymmetry").to.equal(
+			eq(lhs, rhs),
+		);
+	});
 
-	fc.assert(
-		fc.property(arb, arb, arb, (first, second, third) => {
-			if (le(first, second) && le(second, third)) {
-				expect(le(first, third), "transitivity").to.be.true;
-			}
-		}),
-	);
+	const transitivity = fc.property(arb, arb, arb, (first, second, third) => {
+		if (le(first, second) && le(second, third)) {
+			expect(le(first, third), "transitivity").to.be.true;
+		}
+	});
 
-	fc.assert(
-		fc.property(arb, arb, (lhs, rhs) => {
-			expect(le(lhs, rhs) || le(rhs, lhs), "comparability").to.be.true;
-		}),
-	);
+	const comparability = fc.property(arb, arb, (lhs, rhs) => {
+		expect(le(lhs, rhs) || le(rhs, lhs), "comparability").to.be.true;
+	});
+
+	fc.assert(reflexivity);
+	fc.assert(antisymmetry);
+	fc.assert(transitivity);
+	fc.assert(comparability);
 }
 
 export function expectLawfulSemigroup<T extends Semigroup<T> & Eq<T>>(
 	arb: fc.Arbitrary<T>,
 ): void {
-	fc.assert(
-		fc.property(arb, arb, arb, (first, second, third) => {
-			expect(
-				eq(
-					cmb(first, cmb(second, third)),
-					cmb(cmb(first, second), third),
-				),
-				"associativity",
-			).to.be.true;
-		}),
-	);
+	const associativity = fc.property(arb, arb, arb, (first, second, third) => {
+		expect(
+			eq(cmb(first, cmb(second, third)), cmb(cmb(first, second), third)),
+			"associativity",
+		).to.be.true;
+	});
+	fc.assert(associativity);
 }

--- a/src/_test/utils.ts
+++ b/src/_test/utils.ts
@@ -17,7 +17,7 @@
 import * as fc from "fast-check";
 import { expect } from "vitest";
 import { Semigroup, cmb } from "../cmb.js";
-import { Eq, Ord, Ordering, cmp, eq, le } from "../cmp.js";
+import { Eq, Ord, Ordering, eq, le } from "../cmp.js";
 
 export class Num implements Ord<Num> {
 	constructor(readonly val: number) {}
@@ -53,52 +53,52 @@ export function arbStr(): fc.Arbitrary<Str> {
 
 export function expectLawfulEq<T extends Eq<T>>(arb: fc.Arbitrary<T>): void {
 	fc.assert(
-		fc.property(arb, (x) => {
-			expect(eq(x, x), "reflexivity").to.be.true;
+		fc.property(arb, (val) => {
+			expect(eq(val, val), "reflexivity").to.be.true;
 		}),
 	);
 
 	fc.assert(
-		fc.property(arb, arb, (x, y) => {
-			expect(eq(x, y), "symmetry").to.equal(eq(y, x));
+		fc.property(arb, arb, (lhs, rhs) => {
+			expect(eq(lhs, rhs), "symmetry").to.equal(eq(rhs, lhs));
 		}),
 	);
 
 	fc.assert(
-		fc.property(arb, (x) => {
-			const y = x,
-				z = x;
-			expect(eq(x, y) && eq(y, z) && eq(x, z), "transitivity").to.be.true;
+		fc.property(arb, arb, arb, (first, second, third) => {
+			if (eq(first, second) && eq(second, third)) {
+				expect(eq(first, third), "transitivity").to.be.true;
+			}
 		}),
 	);
 }
 
 export function expectLawfulOrd<T extends Ord<T>>(arb: fc.Arbitrary<T>): void {
 	fc.assert(
-		fc.property(arb, (x) => {
-			expect(le(x, x), "reflexivity").to.be.true;
+		fc.property(arb, (val) => {
+			expect(le(val, val), "reflexivity").to.be.true;
 		}),
 	);
 
 	fc.assert(
-		fc.property(arb, arb, (x, y) => {
-			expect(le(x, y) && le(y, x), "antisymmetry").to.equal(eq(x, y));
+		fc.property(arb, arb, (lhs, rhs) => {
+			expect(le(lhs, rhs) && le(rhs, lhs), "antisymmetry").to.equal(
+				eq(lhs, rhs),
+			);
 		}),
 	);
 
 	fc.assert(
-		fc.property(arb, arb, arb, (x, y, z) => {
-			const [x1, y1, z1] = [x, y, z].sort((a, b) =>
-				cmp(a, b).toNumber(),
-			) as [T, T, T];
-			expect(le(x1, y1) && le(y1, z1) && le(x1, z1), "transitivity").to.be
-				.true;
+		fc.property(arb, arb, arb, (first, second, third) => {
+			if (le(first, second) && le(second, third)) {
+				expect(le(first, third), "transitivity").to.be.true;
+			}
 		}),
 	);
 
 	fc.assert(
-		fc.property(arb, arb, (x, y) => {
-			expect(le(x, y) || le(y, x), "comparability").to.be.true;
+		fc.property(arb, arb, (lhs, rhs) => {
+			expect(le(lhs, rhs) || le(rhs, lhs), "comparability").to.be.true;
 		}),
 	);
 }
@@ -107,9 +107,14 @@ export function expectLawfulSemigroup<T extends Semigroup<T> & Eq<T>>(
 	arb: fc.Arbitrary<T>,
 ): void {
 	fc.assert(
-		fc.property(arb, arb, arb, (x, y, z) => {
-			expect(eq(cmb(x, cmb(y, z)), cmb(cmb(x, y), z)), "associativity").to
-				.be.true;
+		fc.property(arb, arb, arb, (first, second, third) => {
+			expect(
+				eq(
+					cmb(first, cmb(second, third)),
+					cmb(cmb(first, second), third),
+				),
+				"associativity",
+			).to.be.true;
 		}),
 	);
 }

--- a/src/cmb.test.ts
+++ b/src/cmb.test.ts
@@ -22,8 +22,8 @@ import { Semigroup, cmb } from "./cmb.js";
 describe("cmb", () => {
 	it("combines the two Semigroup values", () => {
 		fc.assert(
-			fc.property(arbStr(), arbStr(), (x, y) => {
-				expect(cmb(x, y)).to.deep.equal(x[Semigroup.cmb](y));
+			fc.property(arbStr(), arbStr(), (lhs, rhs) => {
+				expect(cmb(lhs, rhs)).to.deep.equal(lhs[Semigroup.cmb](rhs));
 			}),
 		);
 	});

--- a/src/cmb.test.ts
+++ b/src/cmb.test.ts
@@ -21,10 +21,9 @@ import { Semigroup, cmb } from "./cmb.js";
 
 describe("cmb", () => {
 	it("combines the two Semigroup values", () => {
-		fc.assert(
-			fc.property(arbStr(), arbStr(), (lhs, rhs) => {
-				expect(cmb(lhs, rhs)).to.deep.equal(lhs[Semigroup.cmb](rhs));
-			}),
-		);
+		const property = fc.property(arbStr(), arbStr(), (lhs, rhs) => {
+			expect(cmb(lhs, rhs)).to.deep.equal(lhs[Semigroup.cmb](rhs));
+		});
+		fc.assert(property);
 	});
 });

--- a/src/cmp.test.ts
+++ b/src/cmp.test.ts
@@ -46,21 +46,19 @@ import {
 
 describe("eq", () => {
 	it("tests whether the two Eq values are equal", () => {
-		fc.assert(
-			fc.property(arbNum(), arbNum(), (lhs, rhs) => {
-				expect(eq(lhs, rhs)).to.equal(lhs[Eq.eq](rhs));
-			}),
-		);
+		const property = fc.property(arbNum(), arbNum(), (lhs, rhs) => {
+			expect(eq(lhs, rhs)).to.equal(lhs[Eq.eq](rhs));
+		});
+		fc.assert(property);
 	});
 });
 
 describe("ne", () => {
 	it("tests whether the two Eq values are inequal", () => {
-		fc.assert(
-			fc.property(arbNum(), arbNum(), (lhs, rhs) => {
-				expect(ne(lhs, rhs)).to.equal(!lhs[Eq.eq](rhs));
-			}),
-		);
+		const property = fc.property(arbNum(), arbNum(), (lhs, rhs) => {
+			expect(ne(lhs, rhs)).to.equal(!lhs[Eq.eq](rhs));
+		});
+		fc.assert(property);
 	});
 });
 
@@ -74,89 +72,82 @@ describe("ieqBy", () => {
 	});
 
 	it("compares any non-empty iterable and any empty iterable as inequal", () => {
-		fc.assert(
-			fc.property(fc.float({ noNaN: true }), (lhs0) => {
-				expect(ieqBy([lhs0], [], comparer)).to.be.false;
-			}),
-		);
+		const property = fc.property(fc.float({ noNaN: true }), (lhs0) => {
+			expect(ieqBy([lhs0], [], comparer)).to.be.false;
+		});
+		fc.assert(property);
 	});
 
 	it("compares any empty iterable and any non-empty iterable as inequal", () => {
-		fc.assert(
-			fc.property(fc.float({ noNaN: true }), (rhs0) => {
-				expect(ieqBy([], [rhs0], comparer)).to.be.false;
-			}),
-		);
+		const property = fc.property(fc.float({ noNaN: true }), (rhs0) => {
+			expect(ieqBy([], [rhs0], comparer)).to.be.false;
+		});
+		fc.assert(property);
 	});
 
 	it("compares any longer iterable any the shorter iterable as inequal", () => {
-		fc.assert(
-			fc.property(
-				fc.float({ noNaN: true }),
-				fc.float({ noNaN: true }),
-				fc.float({ noNaN: true }),
-				(lhs0, lhs1, rhs0) => {
-					expect(ieqBy([lhs0, lhs1], [rhs0], comparer)).to.be.false;
-				},
-			),
+		const property = fc.property(
+			fc.float({ noNaN: true }),
+			fc.float({ noNaN: true }),
+			fc.float({ noNaN: true }),
+			(lhs0, lhs1, rhs0) => {
+				expect(ieqBy([lhs0, lhs1], [rhs0], comparer)).to.be.false;
+			},
 		);
+		fc.assert(property);
 	});
 
 	it("compares any shorter iterable and any longer iterable as inequal", () => {
-		fc.assert(
-			fc.property(
-				fc.float({ noNaN: true }),
-				fc.float({ noNaN: true }),
-				fc.float({ noNaN: true }),
-				(lhs0, rhs0, rhs1) => {
-					expect(ieqBy([lhs0], [rhs0, rhs1], comparer)).to.be.false;
-				},
-			),
+		const property = fc.property(
+			fc.float({ noNaN: true }),
+			fc.float({ noNaN: true }),
+			fc.float({ noNaN: true }),
+			(lhs0, rhs0, rhs1) => {
+				expect(ieqBy([lhs0], [rhs0, rhs1], comparer)).to.be.false;
+			},
 		);
+		fc.assert(property);
 	});
 
 	it("compares any two same-length iterables lexicographically", () => {
-		fc.assert(
-			fc.property(
-				fc.float({ noNaN: true }),
-				fc.float({ noNaN: true }),
-				fc.float({ noNaN: true }),
-				fc.float({ noNaN: true }),
-				(lhs0, lhs1, rhs0, rhs1) => {
-					expect(
-						ieqBy([lhs0, lhs1], [rhs0, rhs1], comparer),
-					).to.equal(comparer(lhs0, rhs0) && comparer(lhs1, rhs1));
-				},
-			),
+		const property = fc.property(
+			fc.float({ noNaN: true }),
+			fc.float({ noNaN: true }),
+			fc.float({ noNaN: true }),
+			fc.float({ noNaN: true }),
+			(lhs0, lhs1, rhs0, rhs1) => {
+				expect(ieqBy([lhs0, lhs1], [rhs0, rhs1], comparer)).to.equal(
+					comparer(lhs0, rhs0) && comparer(lhs1, rhs1),
+				);
+			},
 		);
+		fc.assert(property);
 	});
 });
 
 describe("ieq", () => {
 	it("compares any two iterables of Eq elements lexicographically", () => {
-		fc.assert(
-			fc.property(
-				arbNum(),
-				arbNum(),
-				arbNum(),
-				arbNum(),
-				(lhs0, lhs1, rhs0, rhs1) => {
-					expect(ieq([lhs0, lhs1], [rhs0, rhs1])).to.equal(
-						eq(lhs0, rhs0) && eq(lhs1, rhs1),
-					);
-				},
-			),
+		const property = fc.property(
+			arbNum(),
+			arbNum(),
+			arbNum(),
+			arbNum(),
+			(lhs0, lhs1, rhs0, rhs1) => {
+				expect(ieq([lhs0, lhs1], [rhs0, rhs1])).to.equal(
+					eq(lhs0, rhs0) && eq(lhs1, rhs1),
+				);
+			},
 		);
+		fc.assert(property);
 	});
 });
 
 describe("cmp", () => {
 	it("compares the first Ord value to the second", () => {
-		fc.assert(
-			fc.property(arbNum(), arbNum(), (lhs, rhs) => {
-				expect(cmp(lhs, rhs)).to.equal(lhs[Ord.cmp](rhs));
-			}),
-		);
+		const property = fc.property(arbNum(), arbNum(), (lhs, rhs) => {
+			expect(cmp(lhs, rhs)).to.equal(lhs[Ord.cmp](rhs));
+		});
+		fc.assert(property);
 	});
 });
 
@@ -170,153 +161,145 @@ describe("icmpBy", () => {
 	});
 
 	it("compares any non-empty iterable as greater than any empty iterable", () => {
-		fc.assert(
-			fc.property(fc.float({ noNaN: true }), (lhs0) => {
-				expect(icmpBy([lhs0], [], comparer)).to.equal(Ordering.greater);
-			}),
-		);
+		const property = fc.property(fc.float({ noNaN: true }), (lhs0) => {
+			expect(icmpBy([lhs0], [], comparer)).to.equal(Ordering.greater);
+		});
+		fc.assert(property);
 	});
 
 	it("compares any empty iterable as less than any non-empty iterable", () => {
-		fc.assert(
-			fc.property(fc.float({ noNaN: true }), (rhs0) => {
-				expect(icmpBy([], [rhs0], comparer)).to.equal(Ordering.less);
-			}),
-		);
+		const property = fc.property(fc.float({ noNaN: true }), (rhs0) => {
+			expect(icmpBy([], [rhs0], comparer)).to.equal(Ordering.less);
+		});
+		fc.assert(property);
 	});
 
 	it("compares any longer iterable to any shorter iterable lexicographically", () => {
-		fc.assert(
-			fc.property(
-				fc.float({ noNaN: true }),
-				fc.float({ noNaN: true }),
-				fc.float({ noNaN: true }),
-				(lhs0, lhs1, rhs0) => {
-					expect(icmpBy([lhs0, lhs1], [rhs0], comparer)).to.equal(
-						cmb(comparer(lhs0, rhs0), Ordering.greater),
-					);
-				},
-			),
+		const property = fc.property(
+			fc.float({ noNaN: true }),
+			fc.float({ noNaN: true }),
+			fc.float({ noNaN: true }),
+			(lhs0, lhs1, rhs0) => {
+				expect(icmpBy([lhs0, lhs1], [rhs0], comparer)).to.equal(
+					cmb(comparer(lhs0, rhs0), Ordering.greater),
+				);
+			},
 		);
+		fc.assert(property);
 	});
 
 	it("compares any shorter iterable to any longer iterable lexicographically", () => {
-		fc.assert(
-			fc.property(
-				fc.float({ noNaN: true }),
-				fc.float({ noNaN: true }),
-				fc.float({ noNaN: true }),
-				(lhs0, rhs0, rhs1) => {
-					expect(icmpBy([lhs0], [rhs0, rhs1], comparer)).to.equal(
-						cmb(comparer(lhs0, rhs0), Ordering.less),
-					);
-				},
-			),
+		const property = fc.property(
+			fc.float({ noNaN: true }),
+			fc.float({ noNaN: true }),
+			fc.float({ noNaN: true }),
+			(lhs0, rhs0, rhs1) => {
+				expect(icmpBy([lhs0], [rhs0, rhs1], comparer)).to.equal(
+					cmb(comparer(lhs0, rhs0), Ordering.less),
+				);
+			},
 		);
+		fc.assert(property);
 	});
 
 	it("compares any two same-length iterables lexicographically", () => {
-		fc.assert(
-			fc.property(
-				fc.float({ noNaN: true }),
-				fc.float({ noNaN: true }),
-				fc.float({ noNaN: true }),
-				fc.float({ noNaN: true }),
-				(lhs0, lhs1, rhs0, rhs1) => {
-					expect(
-						icmpBy([lhs0, lhs1], [rhs0, rhs1], comparer),
-					).to.equal(cmb(comparer(lhs0, rhs0), comparer(lhs1, rhs1)));
-				},
-			),
+		const property = fc.property(
+			fc.float({ noNaN: true }),
+			fc.float({ noNaN: true }),
+			fc.float({ noNaN: true }),
+			fc.float({ noNaN: true }),
+			(lhs0, lhs1, rhs0, rhs1) => {
+				expect(icmpBy([lhs0, lhs1], [rhs0, rhs1], comparer)).to.equal(
+					cmb(comparer(lhs0, rhs0), comparer(lhs1, rhs1)),
+				);
+			},
 		);
+		fc.assert(property);
 	});
 });
 
 describe("icmp", () => {
 	it("compares any two iterables of Ord elements lexicographically", () => {
-		fc.assert(
-			fc.property(
-				arbNum(),
-				arbNum(),
-				arbNum(),
-				arbNum(),
-				(lhs0, lhs1, rhs0, rhs1) => {
-					expect(icmp([lhs0, lhs1], [rhs0, rhs1])).to.equal(
-						cmb(cmp(lhs0, rhs0), cmp(lhs1, rhs1)),
-					);
-				},
-			),
+		const property = fc.property(
+			arbNum(),
+			arbNum(),
+			arbNum(),
+			arbNum(),
+			(lhs0, lhs1, rhs0, rhs1) => {
+				expect(icmp([lhs0, lhs1], [rhs0, rhs1])).to.equal(
+					cmb(cmp(lhs0, rhs0), cmp(lhs1, rhs1)),
+				);
+			},
 		);
+		fc.assert(property);
 	});
 });
 
 describe("lt", () => {
 	it("tests whether the first Ord value is less than the second", () => {
-		fc.assert(
-			fc.property(arbNum(), arbNum(), (lhs, rhs) => {
-				expect(lt(lhs, rhs)).to.equal(cmp(lhs, rhs).isLt());
-			}),
-		);
+		const property = fc.property(arbNum(), arbNum(), (lhs, rhs) => {
+			expect(lt(lhs, rhs)).to.equal(cmp(lhs, rhs).isLt());
+		});
+		fc.assert(property);
 	});
 });
 
 describe("gt", () => {
 	it("tests whether the first Ord value is greater than the second", () => {
-		fc.assert(
-			fc.property(arbNum(), arbNum(), (lhs, rhs) => {
-				expect(gt(lhs, rhs)).to.equal(cmp(lhs, rhs).isGt());
-			}),
-		);
+		const property = fc.property(arbNum(), arbNum(), (lhs, rhs) => {
+			expect(gt(lhs, rhs)).to.equal(cmp(lhs, rhs).isGt());
+		});
+		fc.assert(property);
 	});
 });
 
 describe("le", () => {
 	it("tests whether the first Ord value is less than or equal to the second", () => {
-		fc.assert(
-			fc.property(arbNum(), arbNum(), (lhs, rhs) => {
-				expect(le(lhs, rhs)).to.equal(cmp(lhs, rhs).isLe());
-			}),
-		);
+		const property = fc.property(arbNum(), arbNum(), (lhs, rhs) => {
+			expect(le(lhs, rhs)).to.equal(cmp(lhs, rhs).isLe());
+		});
+		fc.assert(property);
 	});
 });
 
 describe("ge", () => {
 	it("tests whether the first Ord value is greater than or equal to the second", () => {
-		fc.assert(
-			fc.property(arbNum(), arbNum(), (lhs, rhs) => {
-				expect(ge(lhs, rhs)).to.equal(cmp(lhs, rhs).isGe());
-			}),
-		);
+		const property = fc.property(arbNum(), arbNum(), (lhs, rhs) => {
+			expect(ge(lhs, rhs)).to.equal(cmp(lhs, rhs).isGe());
+		});
+		fc.assert(property);
 	});
 });
 
 describe("min", () => {
 	it("returns the lesser of the two Ord values", () => {
-		fc.assert(
-			fc.property(arbNum(), arbNum(), (lhs, rhs) => {
-				expect(min(lhs, rhs)).to.equal(le(lhs, rhs) ? lhs : rhs);
-			}),
-		);
+		const property = fc.property(arbNum(), arbNum(), (lhs, rhs) => {
+			expect(min(lhs, rhs)).to.equal(le(lhs, rhs) ? lhs : rhs);
+		});
+		fc.assert(property);
 	});
 });
 
 describe("max", () => {
 	it("returns the greater of the two Ord values", () => {
-		fc.assert(
-			fc.property(arbNum(), arbNum(), (lhs, rhs) => {
-				expect(max(lhs, rhs)).to.equal(ge(lhs, rhs) ? lhs : rhs);
-			}),
-		);
+		const property = fc.property(arbNum(), arbNum(), (lhs, rhs) => {
+			expect(max(lhs, rhs)).to.equal(ge(lhs, rhs) ? lhs : rhs);
+		});
+		fc.assert(property);
 	});
 });
 
 describe("clamp", () => {
 	it("restricts the Ord value to an inclusive bounds", () => {
-		fc.assert(
-			fc.property(arbNum(), arbNum(), arbNum(), (val, lo, hi) => {
+		const property = fc.property(
+			arbNum(),
+			arbNum(),
+			arbNum(),
+			(val, lo, hi) => {
 				expect(clamp(val, lo, hi)).to.equal(min(max(val, lo), hi));
-			}),
+			},
 		);
+		fc.assert(property);
 	});
 });
 
@@ -331,35 +314,31 @@ describe("Ordering", () => {
 
 	describe("fromNumber", () => {
 		it("returns Less if the argument is less than 0", () => {
-			fc.assert(
-				fc.property(
-					fc.oneof(
-						fc.float({ max: -1, noNaN: true }),
-						fc.bigInt({ max: -1n }),
-					),
-					(input) => {
-						expect(Ordering.fromNumber(input)).to.equal(
-							Ordering.less,
-						);
-					},
+			const property = fc.property(
+				fc.oneof(
+					fc.float({ max: -1, noNaN: true }),
+					fc.bigInt({ max: -1n }),
 				),
+				(input) => {
+					expect(Ordering.fromNumber(input)).to.equal(Ordering.less);
+				},
 			);
+			fc.assert(property);
 		});
 
 		it("returns Greater if the argument is greater than 0", () => {
-			fc.assert(
-				fc.property(
-					fc.oneof(
-						fc.float({ min: 1, noNaN: true }),
-						fc.bigInt({ min: 1n }),
-					),
-					(input) => {
-						expect(Ordering.fromNumber(input)).to.equal(
-							Ordering.greater,
-						);
-					},
+			const property = fc.property(
+				fc.oneof(
+					fc.float({ min: 1, noNaN: true }),
+					fc.bigInt({ min: 1n }),
 				),
+				(input) => {
+					expect(Ordering.fromNumber(input)).to.equal(
+						Ordering.greater,
+					);
+				},
 			);
+			fc.assert(property);
 		});
 
 		it("returns Equal if the argument is 0", () => {
@@ -639,15 +618,14 @@ describe("Reverse", () => {
 
 	describe("#[Eq.eq]", () => {
 		it("compares the underlying values", () => {
-			fc.assert(
-				fc.property(
-					arbReverse(arbNum()),
-					arbReverse(arbNum()),
-					(lhs, rhs) => {
-						expect(eq(lhs, rhs)).to.equal(eq(lhs.val, rhs.val));
-					},
-				),
+			const property = fc.property(
+				arbReverse(arbNum()),
+				arbReverse(arbNum()),
+				(lhs, rhs) => {
+					expect(eq(lhs, rhs)).to.equal(eq(lhs.val, rhs.val));
+				},
 			);
+			fc.assert(property);
 		});
 
 		it("implements a lawful equivalence relation", () => {
@@ -657,17 +635,16 @@ describe("Reverse", () => {
 
 	describe("#[Ord.cmp]", () => {
 		it("reverses the Ordering of the underlying values", () => {
-			fc.assert(
-				fc.property(
-					arbReverse(arbNum()),
-					arbReverse(arbNum()),
-					(lhs, rhs) => {
-						expect(cmp(lhs, rhs)).to.equal(
-							cmp(lhs.val, rhs.val).reverse(),
-						);
-					},
-				),
+			const property = fc.property(
+				arbReverse(arbNum()),
+				arbReverse(arbNum()),
+				(lhs, rhs) => {
+					expect(cmp(lhs, rhs)).to.equal(
+						cmp(lhs.val, rhs.val).reverse(),
+					);
+				},
 			);
+			fc.assert(property);
 		});
 
 		it("implements a lawful total order", () => {

--- a/src/cmp.test.ts
+++ b/src/cmp.test.ts
@@ -47,8 +47,8 @@ import {
 describe("eq", () => {
 	it("tests whether the two Eq values are equal", () => {
 		fc.assert(
-			fc.property(arbNum(), arbNum(), (x, y) => {
-				expect(eq(x, y)).to.equal(x[Eq.eq](y));
+			fc.property(arbNum(), arbNum(), (lhs, rhs) => {
+				expect(eq(lhs, rhs)).to.equal(lhs[Eq.eq](rhs));
 			}),
 		);
 	});
@@ -57,16 +57,16 @@ describe("eq", () => {
 describe("ne", () => {
 	it("tests whether the two Eq values are inequal", () => {
 		fc.assert(
-			fc.property(arbNum(), arbNum(), (x, y) => {
-				expect(ne(x, y)).to.equal(!x[Eq.eq](y));
+			fc.property(arbNum(), arbNum(), (lhs, rhs) => {
+				expect(ne(lhs, rhs)).to.equal(!lhs[Eq.eq](rhs));
 			}),
 		);
 	});
 });
 
 describe("ieqBy", () => {
-	function comparer(x: number, y: number): boolean {
-		return x === y;
+	function comparer(lhs: number, rhs: number): boolean {
+		return lhs === rhs;
 	}
 
 	it("compares any two empty iterables as equal", () => {
@@ -75,16 +75,16 @@ describe("ieqBy", () => {
 
 	it("compares any non-empty iterable and any empty iterable as inequal", () => {
 		fc.assert(
-			fc.property(fc.float({ noNaN: true }), (a) => {
-				expect(ieqBy([a], [], comparer)).to.be.false;
+			fc.property(fc.float({ noNaN: true }), (lhs0) => {
+				expect(ieqBy([lhs0], [], comparer)).to.be.false;
 			}),
 		);
 	});
 
 	it("compares any empty iterable and any non-empty iterable as inequal", () => {
 		fc.assert(
-			fc.property(fc.float({ noNaN: true }), (b) => {
-				expect(ieqBy([], [b], comparer)).to.be.false;
+			fc.property(fc.float({ noNaN: true }), (rhs0) => {
+				expect(ieqBy([], [rhs0], comparer)).to.be.false;
 			}),
 		);
 	});
@@ -95,8 +95,8 @@ describe("ieqBy", () => {
 				fc.float({ noNaN: true }),
 				fc.float({ noNaN: true }),
 				fc.float({ noNaN: true }),
-				(a, x, b) => {
-					expect(ieqBy([a, x], [b], comparer)).to.be.false;
+				(lhs0, lhs1, rhs0) => {
+					expect(ieqBy([lhs0, lhs1], [rhs0], comparer)).to.be.false;
 				},
 			),
 		);
@@ -108,8 +108,8 @@ describe("ieqBy", () => {
 				fc.float({ noNaN: true }),
 				fc.float({ noNaN: true }),
 				fc.float({ noNaN: true }),
-				(a, b, y) => {
-					expect(ieqBy([a], [b, y], comparer)).to.be.false;
+				(lhs0, rhs0, rhs1) => {
+					expect(ieqBy([lhs0], [rhs0, rhs1], comparer)).to.be.false;
 				},
 			),
 		);
@@ -122,10 +122,10 @@ describe("ieqBy", () => {
 				fc.float({ noNaN: true }),
 				fc.float({ noNaN: true }),
 				fc.float({ noNaN: true }),
-				(a, x, b, y) => {
-					expect(ieqBy([a, x], [b, y], comparer)).to.equal(
-						comparer(a, b) && comparer(x, y),
-					);
+				(lhs0, lhs1, rhs0, rhs1) => {
+					expect(
+						ieqBy([lhs0, lhs1], [rhs0, rhs1], comparer),
+					).to.equal(comparer(lhs0, rhs0) && comparer(lhs1, rhs1));
 				},
 			),
 		);
@@ -140,8 +140,10 @@ describe("ieq", () => {
 				arbNum(),
 				arbNum(),
 				arbNum(),
-				(a, x, b, y) => {
-					expect(ieq([a, x], [b, y])).to.equal(eq(a, b) && eq(x, y));
+				(lhs0, lhs1, rhs0, rhs1) => {
+					expect(ieq([lhs0, lhs1], [rhs0, rhs1])).to.equal(
+						eq(lhs0, rhs0) && eq(lhs1, rhs1),
+					);
 				},
 			),
 		);
@@ -151,16 +153,16 @@ describe("ieq", () => {
 describe("cmp", () => {
 	it("compares the first Ord value to the second", () => {
 		fc.assert(
-			fc.property(arbNum(), arbNum(), (x, y) => {
-				expect(cmp(x, y)).to.equal(x[Ord.cmp](y));
+			fc.property(arbNum(), arbNum(), (lhs, rhs) => {
+				expect(cmp(lhs, rhs)).to.equal(lhs[Ord.cmp](rhs));
 			}),
 		);
 	});
 });
 
 describe("icmpBy", () => {
-	function comparer(x: number, y: number): Ordering {
-		return Ordering.fromNumber(x - y);
+	function comparer(lhs: number, rhs: number): Ordering {
+		return Ordering.fromNumber(lhs - rhs);
 	}
 
 	it("compares any two empty iterables as equal", () => {
@@ -169,16 +171,16 @@ describe("icmpBy", () => {
 
 	it("compares any non-empty iterable as greater than any empty iterable", () => {
 		fc.assert(
-			fc.property(fc.float({ noNaN: true }), (a) => {
-				expect(icmpBy([a], [], comparer)).to.equal(Ordering.greater);
+			fc.property(fc.float({ noNaN: true }), (lhs0) => {
+				expect(icmpBy([lhs0], [], comparer)).to.equal(Ordering.greater);
 			}),
 		);
 	});
 
 	it("compares any empty iterable as less than any non-empty iterable", () => {
 		fc.assert(
-			fc.property(fc.float({ noNaN: true }), (b) => {
-				expect(icmpBy([], [b], comparer)).to.equal(Ordering.less);
+			fc.property(fc.float({ noNaN: true }), (rhs0) => {
+				expect(icmpBy([], [rhs0], comparer)).to.equal(Ordering.less);
 			}),
 		);
 	});
@@ -189,9 +191,9 @@ describe("icmpBy", () => {
 				fc.float({ noNaN: true }),
 				fc.float({ noNaN: true }),
 				fc.float({ noNaN: true }),
-				(a, x, b) => {
-					expect(icmpBy([a, x], [b], comparer)).to.equal(
-						cmb(comparer(a, b), Ordering.greater),
+				(lhs0, lhs1, rhs0) => {
+					expect(icmpBy([lhs0, lhs1], [rhs0], comparer)).to.equal(
+						cmb(comparer(lhs0, rhs0), Ordering.greater),
 					);
 				},
 			),
@@ -204,9 +206,9 @@ describe("icmpBy", () => {
 				fc.float({ noNaN: true }),
 				fc.float({ noNaN: true }),
 				fc.float({ noNaN: true }),
-				(a, b, y) => {
-					expect(icmpBy([a], [b, y], comparer)).to.equal(
-						cmb(comparer(a, b), Ordering.less),
+				(lhs0, rhs0, rhs1) => {
+					expect(icmpBy([lhs0], [rhs0, rhs1], comparer)).to.equal(
+						cmb(comparer(lhs0, rhs0), Ordering.less),
 					);
 				},
 			),
@@ -220,10 +222,10 @@ describe("icmpBy", () => {
 				fc.float({ noNaN: true }),
 				fc.float({ noNaN: true }),
 				fc.float({ noNaN: true }),
-				(a, x, b, y) => {
-					expect(icmpBy([a, x], [b, y], comparer)).to.equal(
-						cmb(comparer(a, b), comparer(x, y)),
-					);
+				(lhs0, lhs1, rhs0, rhs1) => {
+					expect(
+						icmpBy([lhs0, lhs1], [rhs0, rhs1], comparer),
+					).to.equal(cmb(comparer(lhs0, rhs0), comparer(lhs1, rhs1)));
 				},
 			),
 		);
@@ -238,9 +240,9 @@ describe("icmp", () => {
 				arbNum(),
 				arbNum(),
 				arbNum(),
-				(a, x, b, y) => {
-					expect(icmp([a, x], [b, y])).to.equal(
-						cmb(cmp(a, b), cmp(x, y)),
+				(lhs0, lhs1, rhs0, rhs1) => {
+					expect(icmp([lhs0, lhs1], [rhs0, rhs1])).to.equal(
+						cmb(cmp(lhs0, rhs0), cmp(lhs1, rhs1)),
 					);
 				},
 			),
@@ -251,8 +253,8 @@ describe("icmp", () => {
 describe("lt", () => {
 	it("tests whether the first Ord value is less than the second", () => {
 		fc.assert(
-			fc.property(arbNum(), arbNum(), (x, y) => {
-				expect(lt(x, y)).to.equal(cmp(x, y).isLt());
+			fc.property(arbNum(), arbNum(), (lhs, rhs) => {
+				expect(lt(lhs, rhs)).to.equal(cmp(lhs, rhs).isLt());
 			}),
 		);
 	});
@@ -261,8 +263,8 @@ describe("lt", () => {
 describe("gt", () => {
 	it("tests whether the first Ord value is greater than the second", () => {
 		fc.assert(
-			fc.property(arbNum(), arbNum(), (x, y) => {
-				expect(gt(x, y)).to.equal(cmp(x, y).isGt());
+			fc.property(arbNum(), arbNum(), (lhs, rhs) => {
+				expect(gt(lhs, rhs)).to.equal(cmp(lhs, rhs).isGt());
 			}),
 		);
 	});
@@ -271,8 +273,8 @@ describe("gt", () => {
 describe("le", () => {
 	it("tests whether the first Ord value is less than or equal to the second", () => {
 		fc.assert(
-			fc.property(arbNum(), arbNum(), (x, y) => {
-				expect(le(x, y)).to.equal(cmp(x, y).isLe());
+			fc.property(arbNum(), arbNum(), (lhs, rhs) => {
+				expect(le(lhs, rhs)).to.equal(cmp(lhs, rhs).isLe());
 			}),
 		);
 	});
@@ -281,8 +283,8 @@ describe("le", () => {
 describe("ge", () => {
 	it("tests whether the first Ord value is greater than or equal to the second", () => {
 		fc.assert(
-			fc.property(arbNum(), arbNum(), (x, y) => {
-				expect(ge(x, y)).to.equal(cmp(x, y).isGe());
+			fc.property(arbNum(), arbNum(), (lhs, rhs) => {
+				expect(ge(lhs, rhs)).to.equal(cmp(lhs, rhs).isGe());
 			}),
 		);
 	});
@@ -291,8 +293,8 @@ describe("ge", () => {
 describe("min", () => {
 	it("returns the lesser of the two Ord values", () => {
 		fc.assert(
-			fc.property(arbNum(), arbNum(), (x, y) => {
-				expect(min(x, y)).to.equal(le(x, y) ? x : y);
+			fc.property(arbNum(), arbNum(), (lhs, rhs) => {
+				expect(min(lhs, rhs)).to.equal(le(lhs, rhs) ? lhs : rhs);
 			}),
 		);
 	});
@@ -301,8 +303,8 @@ describe("min", () => {
 describe("max", () => {
 	it("returns the greater of the two Ord values", () => {
 		fc.assert(
-			fc.property(arbNum(), arbNum(), (x, y) => {
-				expect(max(x, y)).to.equal(ge(x, y) ? x : y);
+			fc.property(arbNum(), arbNum(), (lhs, rhs) => {
+				expect(max(lhs, rhs)).to.equal(ge(lhs, rhs) ? lhs : rhs);
 			}),
 		);
 	});
@@ -311,8 +313,8 @@ describe("max", () => {
 describe("clamp", () => {
 	it("restricts the Ord value to an inclusive bounds", () => {
 		fc.assert(
-			fc.property(arbNum(), arbNum(), arbNum(), (x, y, z) => {
-				expect(clamp(x, y, z)).to.equal(min(max(x, y), z));
+			fc.property(arbNum(), arbNum(), arbNum(), (val, lo, hi) => {
+				expect(clamp(val, lo, hi)).to.equal(min(max(val, lo), hi));
 			}),
 		);
 	});
@@ -331,9 +333,14 @@ describe("Ordering", () => {
 		it("returns Less if the argument is less than 0", () => {
 			fc.assert(
 				fc.property(
-					fc.float({ min: -Infinity, max: -1, noNaN: true }),
-					(x) => {
-						expect(Ordering.fromNumber(x)).to.equal(Ordering.less);
+					fc.oneof(
+						fc.float({ max: -1, noNaN: true }),
+						fc.bigInt({ max: -1n }),
+					),
+					(input) => {
+						expect(Ordering.fromNumber(input)).to.equal(
+							Ordering.less,
+						);
 					},
 				),
 			);
@@ -342,9 +349,12 @@ describe("Ordering", () => {
 		it("returns Greater if the argument is greater than 0", () => {
 			fc.assert(
 				fc.property(
-					fc.float({ min: 1, max: Infinity, noNaN: true }),
-					(x) => {
-						expect(Ordering.fromNumber(x)).to.equal(
+					fc.oneof(
+						fc.float({ min: 1, noNaN: true }),
+						fc.bigInt({ min: 1n }),
+					),
+					(input) => {
+						expect(Ordering.fromNumber(input)).to.equal(
 							Ordering.greater,
 						);
 					},
@@ -633,8 +643,8 @@ describe("Reverse", () => {
 				fc.property(
 					arbReverse(arbNum()),
 					arbReverse(arbNum()),
-					(x, y) => {
-						expect(eq(x, y)).to.equal(eq(x.val, y.val));
+					(lhs, rhs) => {
+						expect(eq(lhs, rhs)).to.equal(eq(lhs.val, rhs.val));
 					},
 				),
 			);
@@ -651,8 +661,10 @@ describe("Reverse", () => {
 				fc.property(
 					arbReverse(arbNum()),
 					arbReverse(arbNum()),
-					(x, y) => {
-						expect(cmp(x, y)).to.equal(cmp(x.val, y.val).reverse());
+					(lhs, rhs) => {
+						expect(cmp(lhs, rhs)).to.equal(
+							cmp(lhs.val, rhs.val).reverse(),
+						);
 					},
 				),
 			);

--- a/src/either.test.ts
+++ b/src/either.test.ts
@@ -224,39 +224,35 @@ describe("Either", () => {
 
 	describe("#[Eq.eq]", () => {
 		it("compares the values if both variants are Left", () => {
-			fc.assert(
-				fc.property(arbNum(), arbNum(), (lhs, rhs) => {
-					expect(eq(Either.left(lhs), Either.left(rhs))).to.equal(
-						eq(lhs, rhs),
-					);
-				}),
-			);
+			const property = fc.property(arbNum(), arbNum(), (lhs, rhs) => {
+				expect(eq(Either.left(lhs), Either.left(rhs))).to.equal(
+					eq(lhs, rhs),
+				);
+			});
+			fc.assert(property);
 		});
 
 		it("compares any Left and any Right as inequal", () => {
-			fc.assert(
-				fc.property(arbNum(), arbNum(), (lhs, rhs) => {
-					expect(eq(Either.left(lhs), Either.right(rhs))).to.be.false;
-				}),
-			);
+			const property = fc.property(arbNum(), arbNum(), (lhs, rhs) => {
+				expect(eq(Either.left(lhs), Either.right(rhs))).to.be.false;
+			});
+			fc.assert(property);
 		});
 
 		it("compares any Right and any Left as inequal", () => {
-			fc.assert(
-				fc.property(arbNum(), arbNum(), (lhs, rhs) => {
-					expect(eq(Either.right(lhs), Either.left(rhs))).to.be.false;
-				}),
-			);
+			const property = fc.property(arbNum(), arbNum(), (lhs, rhs) => {
+				expect(eq(Either.right(lhs), Either.left(rhs))).to.be.false;
+			});
+			fc.assert(property);
 		});
 
 		it("compares the values if both variants are Right", () => {
-			fc.assert(
-				fc.property(arbNum(), arbNum(), (lhs, rhs) => {
-					expect(eq(Either.right(lhs), Either.right(rhs))).to.equal(
-						eq(lhs, rhs),
-					);
-				}),
-			);
+			const property = fc.property(arbNum(), arbNum(), (lhs, rhs) => {
+				expect(eq(Either.right(lhs), Either.right(rhs))).to.equal(
+					eq(lhs, rhs),
+				);
+			});
+			fc.assert(property);
 		});
 
 		it("implements a lawful equivalence relation", () => {
@@ -266,43 +262,39 @@ describe("Either", () => {
 
 	describe("#[Ord.cmp]", () => {
 		it("compares the values if both variants are Left", () => {
-			fc.assert(
-				fc.property(arbNum(), arbNum(), (lhs, rhs) => {
-					expect(cmp(Either.left(lhs), Either.left(rhs))).to.equal(
-						cmp(lhs, rhs),
-					);
-				}),
-			);
+			const property = fc.property(arbNum(), arbNum(), (lhs, rhs) => {
+				expect(cmp(Either.left(lhs), Either.left(rhs))).to.equal(
+					cmp(lhs, rhs),
+				);
+			});
+			fc.assert(property);
 		});
 
 		it("compares any Left as less than any Right", () => {
-			fc.assert(
-				fc.property(arbNum(), arbNum(), (lhs, rhs) => {
-					expect(cmp(Either.left(lhs), Either.right(rhs))).to.equal(
-						Ordering.less,
-					);
-				}),
-			);
+			const property = fc.property(arbNum(), arbNum(), (lhs, rhs) => {
+				expect(cmp(Either.left(lhs), Either.right(rhs))).to.equal(
+					Ordering.less,
+				);
+			});
+			fc.assert(property);
 		});
 
 		it("compares any Right as greater than any Left", () => {
-			fc.assert(
-				fc.property(arbNum(), arbNum(), (lhs, rhs) => {
-					expect(cmp(Either.right(lhs), Either.left(rhs))).to.equal(
-						Ordering.greater,
-					);
-				}),
-			);
+			const property = fc.property(arbNum(), arbNum(), (lhs, rhs) => {
+				expect(cmp(Either.right(lhs), Either.left(rhs))).to.equal(
+					Ordering.greater,
+				);
+			});
+			fc.assert(property);
 		});
 
 		it("compares the values if both variants are Right", () => {
-			fc.assert(
-				fc.property(arbNum(), arbNum(), (lhs, rhs) => {
-					expect(cmp(Either.right(lhs), Either.right(rhs))).to.equal(
-						cmp(lhs, rhs),
-					);
-				}),
-			);
+			const property = fc.property(arbNum(), arbNum(), (lhs, rhs) => {
+				expect(cmp(Either.right(lhs), Either.right(rhs))).to.equal(
+					cmp(lhs, rhs),
+				);
+			});
+			fc.assert(property);
 		});
 
 		it("implements a lawful total order", () => {
@@ -312,13 +304,12 @@ describe("Either", () => {
 
 	describe("#[Semigroup.cmb]", () => {
 		it("combines the values if both variants are Right", () => {
-			fc.assert(
-				fc.property(arbStr(), arbStr(), (lhs, rhs) => {
-					expect(
-						cmb(Either.right(lhs), Either.right(rhs)),
-					).to.deep.equal(Either.right(cmb(lhs, rhs)));
-				}),
-			);
+			const property = fc.property(arbStr(), arbStr(), (lhs, rhs) => {
+				expect(cmb(Either.right(lhs), Either.right(rhs))).to.deep.equal(
+					Either.right(cmb(lhs, rhs)),
+				);
+			});
+			fc.assert(property);
 		});
 
 		it("implements a lawful semigroup", () => {

--- a/src/either.test.ts
+++ b/src/either.test.ts
@@ -68,33 +68,30 @@ describe("Either", () => {
 
 	describe("go", () => {
 		it("short-cicruits on the first yielded Left", () => {
-			function* f(): Either.Go<1 | [2, 3], [2, 4]> {
-				const x = yield* Either.right<2, 1>(2);
-				const y = yield* Either.left<[2, 3], 4>([x, 3]);
-				return [x, y];
+			function* f(): Either.Go<1 | 3, [2, 4]> {
+				const two = yield* Either.right<2, 1>(2);
+				const four = yield* Either.left<3, 4>(3);
+				return [two, four];
 			}
 			const either = Either.go(f());
-			expect(either).to.deep.equal(Either.left([2, 3]));
+			expect(either).to.deep.equal(Either.left(3));
 		});
 
 		it("completes if all yielded values are Right", () => {
-			function* f(): Either.Go<1 | 3, [2, 2, 4]> {
-				const x = yield* Either.right<2, 1>(2);
-				const [y, z] = yield* Either.right<[2, 4], 3>([x, 4]);
-				return [x, y, z];
+			function* f(): Either.Go<1 | 3, [2, 4]> {
+				const two = yield* Either.right<2, 1>(2);
+				const four = yield* Either.right<4, 3>(4);
+				return [two, four];
 			}
 			const either = Either.go(f());
-			expect(either).to.deep.equal(Either.right([2, 2, 4]));
+			expect(either).to.deep.equal(Either.right([2, 4]));
 		});
 
 		it("executes the finally block if a Left is yielded in the try block", () => {
 			const logs: string[] = [];
-			function* f(): Either.Go<1, number[]> {
+			function* f(): Either.Go<1, 2> {
 				try {
-					const results = [];
-					const x = yield* Either.left<1, 2>(1);
-					results.push(x);
-					return results;
+					return yield* Either.left<1, 2>(1);
 				} finally {
 					logs.push("finally");
 				}
@@ -105,12 +102,9 @@ describe("Either", () => {
 		});
 
 		it("keeps the most recent yielded Left when using try and finally blocks", () => {
-			function* f(): Either.Go<1 | 3, number[]> {
+			function* f(): Either.Go<1 | 3, 2> {
 				try {
-					const results = [];
-					const x = yield* Either.left<1, 2>(1);
-					results.push(x);
-					return results;
+					return yield* Either.left<1, 2>(1);
 				} finally {
 					yield* Either.left<3, 4>(3);
 				}
@@ -124,7 +118,7 @@ describe("Either", () => {
 		it("reduces the finite iterable from left to right in the context of Either", () => {
 			const either = Either.reduce(
 				["x", "y"],
-				(xs, x) => Either.right<string, 1>(xs + x),
+				(chars, char) => Either.right<string, 1>(chars + char),
 				"",
 			);
 			expect(either).to.deep.equal(Either.right("xy"));
@@ -144,10 +138,10 @@ describe("Either", () => {
 	describe("allProps", () => {
 		it("turns the record or the object literal of Either elements inside out", () => {
 			const either = Either.allProps({
-				x: Either.right<2, 1>(2),
-				y: Either.right<4, 3>(4),
+				two: Either.right<2, 1>(2),
+				four: Either.right<4, 3>(4),
 			});
-			expect(either).to.deep.equal(Either.right({ x: 2, y: 4 }));
+			expect(either).to.deep.equal(Either.right({ two: 2, four: 4 }));
 		});
 	});
 
@@ -166,53 +160,46 @@ describe("Either", () => {
 
 	describe("goAsync", () => {
 		it("short-circuits on the first yielded Left", async () => {
-			async function* f(): Either.GoAsync<1 | [2, 3], [2, 4]> {
-				const x = yield* await Promise.resolve(Either.right<2, 1>(2));
-				const y = yield* await Promise.resolve(
-					Either.left<[2, 3], 4>([x, 3]),
-				);
-				return [x, y];
+			async function* f(): Either.GoAsync<1 | 3, [2, 4]> {
+				const two = yield* await Promise.resolve(Either.right<2, 1>(2));
+				const four = yield* await Promise.resolve(Either.left<3, 4>(3));
+				return [two, four];
 			}
 			const either = await Either.goAsync(f());
-			expect(either).to.deep.equal(Either.left([2, 3]));
+			expect(either).to.deep.equal(Either.left(3));
 		});
 
 		it("completes and returns if all yielded values are Right", async () => {
-			async function* f(): Either.GoAsync<1 | 3, [2, 2, 4]> {
-				const x = yield* await Promise.resolve(Either.right<2, 1>(2));
-				const [y, z] = yield* await Promise.resolve(
-					Either.right<[2, 4], 3>([x, 4]),
+			async function* f(): Either.GoAsync<1 | 3, [2, 4]> {
+				const two = yield* await Promise.resolve(Either.right<2, 1>(2));
+				const four = yield* await Promise.resolve(
+					Either.right<4, 3>(4),
 				);
-				return [x, y, z];
+				return [two, four];
 			}
 			const either = await Either.goAsync(f());
-			expect(either).to.deep.equal(Either.right([2, 2, 4]));
+			expect(either).to.deep.equal(Either.right([2, 4]));
 		});
 
 		it("unwraps Promises in Right variants and in return", async () => {
-			async function* f(): Either.GoAsync<1 | 3, [2, 2, 4]> {
-				const x = yield* await Promise.resolve(
+			async function* f(): Either.GoAsync<1 | 3, [2, 4]> {
+				const two = yield* await Promise.resolve(
 					Either.right<Promise<2>, 1>(Promise.resolve(2)),
 				);
-				const [y, z] = yield* await Promise.resolve(
-					Either.right<Promise<[2, 4]>, 3>(Promise.resolve([x, 4])),
+				const four = yield* await Promise.resolve(
+					Either.right<Promise<4>, 3>(Promise.resolve(4)),
 				);
-				return Promise.resolve([x, y, z]);
+				return Promise.resolve([two, four]);
 			}
 			const either = await Either.goAsync(f());
-			expect(either).to.deep.equal(Either.right([2, 2, 4]));
+			expect(either).to.deep.equal(Either.right([2, 4]));
 		});
 
 		it("executes the finally block if a Left is yielded in the try block", async () => {
 			const logs: string[] = [];
-			async function* f(): Either.GoAsync<1, number[]> {
+			async function* f(): Either.GoAsync<1, 2> {
 				try {
-					const results = [];
-					const x = yield* await Promise.resolve(
-						Either.left<1, 2>(1),
-					);
-					results.push(x);
-					return results;
+					return yield* await Promise.resolve(Either.left<1, 2>(1));
 				} finally {
 					logs.push("finally");
 				}
@@ -223,14 +210,9 @@ describe("Either", () => {
 		});
 
 		it("keeps the most recent yielded Left when using try and finally blocks", async () => {
-			async function* f(): Either.GoAsync<1 | 3, number[]> {
+			async function* f(): Either.GoAsync<1 | 3, 2> {
 				try {
-					const results = [];
-					const x = yield* await Promise.resolve(
-						Either.left<1, 2>(1),
-					);
-					results.push(x);
-					return results;
+					return yield* await Promise.resolve(Either.left<1, 2>(1));
 				} finally {
 					yield* await Promise.resolve(Either.left<3, 4>(3));
 				}
@@ -243,9 +225,9 @@ describe("Either", () => {
 	describe("#[Eq.eq]", () => {
 		it("compares the values if both variants are Left", () => {
 			fc.assert(
-				fc.property(arbNum(), arbNum(), (x, y) => {
-					expect(eq(Either.left(x), Either.left(y))).to.equal(
-						eq(x, y),
+				fc.property(arbNum(), arbNum(), (lhs, rhs) => {
+					expect(eq(Either.left(lhs), Either.left(rhs))).to.equal(
+						eq(lhs, rhs),
 					);
 				}),
 			);
@@ -253,25 +235,25 @@ describe("Either", () => {
 
 		it("compares any Left and any Right as inequal", () => {
 			fc.assert(
-				fc.property(arbNum(), arbNum(), (x, y) => {
-					expect(eq(Either.left(x), Either.right(y))).to.be.false;
+				fc.property(arbNum(), arbNum(), (lhs, rhs) => {
+					expect(eq(Either.left(lhs), Either.right(rhs))).to.be.false;
 				}),
 			);
 		});
 
 		it("compares any Right and any Left as inequal", () => {
 			fc.assert(
-				fc.property(arbNum(), arbNum(), (x, y) => {
-					expect(eq(Either.right(x), Either.left(y))).to.be.false;
+				fc.property(arbNum(), arbNum(), (lhs, rhs) => {
+					expect(eq(Either.right(lhs), Either.left(rhs))).to.be.false;
 				}),
 			);
 		});
 
 		it("compares the values if both variants are Right", () => {
 			fc.assert(
-				fc.property(arbNum(), arbNum(), (x, y) => {
-					expect(eq(Either.right(x), Either.right(y))).to.equal(
-						eq(x, y),
+				fc.property(arbNum(), arbNum(), (lhs, rhs) => {
+					expect(eq(Either.right(lhs), Either.right(rhs))).to.equal(
+						eq(lhs, rhs),
 					);
 				}),
 			);
@@ -285,9 +267,9 @@ describe("Either", () => {
 	describe("#[Ord.cmp]", () => {
 		it("compares the values if both variants are Left", () => {
 			fc.assert(
-				fc.property(arbNum(), arbNum(), (x, y) => {
-					expect(cmp(Either.left(x), Either.left(y))).to.equal(
-						cmp(x, y),
+				fc.property(arbNum(), arbNum(), (lhs, rhs) => {
+					expect(cmp(Either.left(lhs), Either.left(rhs))).to.equal(
+						cmp(lhs, rhs),
 					);
 				}),
 			);
@@ -295,8 +277,8 @@ describe("Either", () => {
 
 		it("compares any Left as less than any Right", () => {
 			fc.assert(
-				fc.property(arbNum(), arbNum(), (x, y) => {
-					expect(cmp(Either.left(x), Either.right(y))).to.equal(
+				fc.property(arbNum(), arbNum(), (lhs, rhs) => {
+					expect(cmp(Either.left(lhs), Either.right(rhs))).to.equal(
 						Ordering.less,
 					);
 				}),
@@ -305,8 +287,8 @@ describe("Either", () => {
 
 		it("compares any Right as greater than any Left", () => {
 			fc.assert(
-				fc.property(arbNum(), arbNum(), (x, y) => {
-					expect(cmp(Either.right(x), Either.left(y))).to.equal(
+				fc.property(arbNum(), arbNum(), (lhs, rhs) => {
+					expect(cmp(Either.right(lhs), Either.left(rhs))).to.equal(
 						Ordering.greater,
 					);
 				}),
@@ -315,9 +297,9 @@ describe("Either", () => {
 
 		it("compares the values if both variants are Right", () => {
 			fc.assert(
-				fc.property(arbNum(), arbNum(), (x, y) => {
-					expect(cmp(Either.right(x), Either.right(y))).to.equal(
-						cmp(x, y),
+				fc.property(arbNum(), arbNum(), (lhs, rhs) => {
+					expect(cmp(Either.right(lhs), Either.right(rhs))).to.equal(
+						cmp(lhs, rhs),
 					);
 				}),
 			);
@@ -331,10 +313,10 @@ describe("Either", () => {
 	describe("#[Semigroup.cmb]", () => {
 		it("combines the values if both variants are Right", () => {
 			fc.assert(
-				fc.property(arbStr(), arbStr(), (x, y) => {
-					expect(cmb(Either.right(x), Either.right(y))).to.deep.equal(
-						Either.right(cmb(x, y)),
-					);
+				fc.property(arbStr(), arbStr(), (lhs, rhs) => {
+					expect(
+						cmb(Either.right(lhs), Either.right(rhs)),
+					).to.deep.equal(Either.right(cmb(lhs, rhs)));
 				}),
 			);
 		});
@@ -367,16 +349,16 @@ describe("Either", () => {
 	describe("#unwrap", () => {
 		it("applies the first function to the value if the variant is Left", () => {
 			const result = Either.left<1, 2>(1).unwrap(
-				(x): [1, 3] => [x, 3],
-				(x): [2, 4] => [x, 4],
+				(one): [1, 3] => [one, 3],
+				(two): [2, 4] => [two, 4],
 			);
 			expect(result).to.deep.equal([1, 3]);
 		});
 
 		it("applies the second function to the value if the variant is Right", () => {
 			const result = Either.right<2, 1>(2).unwrap(
-				(x): [1, 3] => [x, 3],
-				(x): [2, 4] => [x, 4],
+				(one): [1, 3] => [one, 3],
+				(two): [2, 4] => [two, 4],
 			);
 			expect(result).to.deep.equal([2, 4]);
 		});
@@ -385,14 +367,14 @@ describe("Either", () => {
 	describe("#recover", () => {
 		it("applies the continuation to the failure if the variant is Left", () => {
 			const either = Either.left<1, 2>(1).recover(
-				(x): Either<[1, 3], 4> => Either.left([x, 3]),
+				(one): Either<[1, 3], 4> => Either.left([one, 3]),
 			);
 			expect(either).to.deep.equal(Either.left([1, 3]));
 		});
 
 		it("does not apply the continuation if the variant is Right", () => {
 			const either = Either.right<2, 1>(2).recover(
-				(x): Either<[1, 3], 4> => Either.left([x, 3]),
+				(one): Either<[1, 3], 4> => Either.left([one, 3]),
 			);
 			expect(either).to.deep.equal(Either.right(2));
 		});
@@ -401,14 +383,14 @@ describe("Either", () => {
 	describe("#flatMap", () => {
 		it("does not apply the continuation if the variant is Left", () => {
 			const either = Either.left<1, 2>(1).flatMap(
-				(x): Either<3, [2, 4]> => Either.right([x, 4]),
+				(two): Either<3, [2, 4]> => Either.right([two, 4]),
 			);
 			expect(either).to.deep.equal(Either.left(1));
 		});
 
 		it("applies the continuation to the success if the variant is Right", () => {
 			const either = Either.right<2, 1>(2).flatMap(
-				(x): Either<3, [2, 4]> => Either.right([x, 4]),
+				(two): Either<3, [2, 4]> => Either.right([two, 4]),
 			);
 			expect(either).to.deep.equal(Either.right([2, 4]));
 		});
@@ -416,17 +398,21 @@ describe("Either", () => {
 
 	describe("#goMap", () => {
 		it("does not apply the continuation if the variant is Left", () => {
-			const either = Either.left<1, 2>(1).goMap(function* (x) {
-				const y = yield* Either.right<4, 3>(4);
-				return [x, y] as [2, 4];
+			const either = Either.left<1, 2>(1).goMap(function* (
+				two,
+			): Either.Go<3, [2, 4]> {
+				const four = yield* Either.right<4, 3>(4);
+				return [two, four];
 			});
 			expect(either).to.deep.equal(Either.left(1));
 		});
 
 		it("applies the continuation to the success if the variant is Right", () => {
-			const either = Either.right<2, 1>(2).goMap(function* (x) {
-				const y = yield* Either.right<4, 3>(4);
-				return [x, y] as [2, 4];
+			const either = Either.right<2, 1>(2).goMap(function* (
+				two,
+			): Either.Go<3, [2, 4]> {
+				const four = yield* Either.right<4, 3>(4);
+				return [two, four];
 			});
 			expect(either).to.deep.equal(Either.right([2, 4]));
 		});
@@ -436,7 +422,7 @@ describe("Either", () => {
 		it("applies the function to the successes if both variants are Right", () => {
 			const either = Either.right<2, 1>(2).zipWith(
 				Either.right<4, 3>(4),
-				(lhs, rhs): [2, 4] => [lhs, rhs],
+				(two, four): [2, 4] => [two, four],
 			);
 			expect(either).to.deep.equal(Either.right([2, 4]));
 		});
@@ -458,14 +444,14 @@ describe("Either", () => {
 
 	describe("#lmap", () => {
 		it("applies the function to the value if the variant is Left", () => {
-			const either = Either.left<1, 2>(1).lmap((x): [1, 3] => [x, 3]);
+			const either = Either.left<1, 2>(1).lmap((one): [1, 3] => [one, 3]);
 			expect(either).to.deep.equal(Either.left([1, 3]));
 		});
 	});
 
 	describe("#map", () => {
 		it("applies the function to the value if the variant is Right", () => {
-			const either = Either.right<2, 1>(2).map((x): [2, 4] => [x, 4]);
+			const either = Either.right<2, 1>(2).map((two): [2, 4] => [two, 4]);
 			expect(either).to.deep.equal(Either.right([2, 4]));
 		});
 	});

--- a/src/eval.test.ts
+++ b/src/eval.test.ts
@@ -127,13 +127,12 @@ describe("Eval", () => {
 
 	describe("#[Semigroup.cmb]", () => {
 		it("combines the outcomes", () => {
-			fc.assert(
-				fc.property(arbStr(), arbStr(), (lhs, rhs) => {
-					expect(
-						cmb(Eval.now(lhs), Eval.now(rhs)).run(),
-					).to.deep.equal(cmb(lhs, rhs));
-				}),
-			);
+			const property = fc.property(arbStr(), arbStr(), (lhs, rhs) => {
+				expect(cmb(Eval.now(lhs), Eval.now(rhs)).run()).to.deep.equal(
+					cmb(lhs, rhs),
+				);
+			});
+			fc.assert(property);
 		});
 
 		it("implements a lawful semigroup", () => {

--- a/src/fn.test.ts
+++ b/src/fn.test.ts
@@ -21,8 +21,8 @@ import { constant, id, negatePred, wrapCtor } from "./fn.js";
 describe("id", () => {
 	it("returns its argument", () => {
 		fc.assert(
-			fc.property(fc.anything(), (x) => {
-				expect(id(x)).to.deep.equal(x);
+			fc.property(fc.anything(), (val) => {
+				expect(id(val)).to.deep.equal(val);
 			}),
 		);
 	});
@@ -31,9 +31,9 @@ describe("id", () => {
 describe("constant", () => {
 	it("returns a function that returns the original argument regardless of the provided arguments", () => {
 		fc.assert(
-			fc.property(fc.anything(), fc.array(fc.anything()), (x, args) => {
-				const f = constant(x);
-				expect(f(...args)).to.deep.equal(x);
+			fc.property(fc.anything(), fc.array(fc.anything()), (val, args) => {
+				const f = constant(val);
+				expect(f(...args)).to.deep.equal(val);
 			}),
 		);
 	});
@@ -41,8 +41,8 @@ describe("constant", () => {
 
 describe("negatePred", () => {
 	it("adapts the predicate into an identical predicate that negates its result", () => {
-		function isOne(x: 1 | 2): boolean {
-			return x === 1;
+		function isOne(num: number): boolean {
+			return num === 1;
 		}
 		const isNotOne = negatePred(isOne);
 

--- a/src/fn.test.ts
+++ b/src/fn.test.ts
@@ -20,22 +20,24 @@ import { constant, id, negatePred, wrapCtor } from "./fn.js";
 
 describe("id", () => {
 	it("returns its argument", () => {
-		fc.assert(
-			fc.property(fc.anything(), (val) => {
-				expect(id(val)).to.deep.equal(val);
-			}),
-		);
+		const property = fc.property(fc.anything(), (val) => {
+			expect(id(val)).to.deep.equal(val);
+		});
+		fc.assert(property);
 	});
 });
 
 describe("constant", () => {
 	it("returns a function that returns the original argument regardless of the provided arguments", () => {
-		fc.assert(
-			fc.property(fc.anything(), fc.array(fc.anything()), (val, args) => {
+		const property = fc.property(
+			fc.anything(),
+			fc.array(fc.anything()),
+			(val, args) => {
 				const f = constant(val);
 				expect(f(...args)).to.deep.equal(val);
-			}),
+			},
 		);
+		fc.assert(property);
 	});
 });
 

--- a/src/ior.test.ts
+++ b/src/ior.test.ts
@@ -379,111 +379,102 @@ describe("Ior", () => {
 
 	describe("#[Eq.eq]", () => {
 		it("compares the values if both variants are Left", () => {
-			fc.assert(
-				fc.property(arbNum(), arbNum(), (lhs0, rhs0) => {
-					expect(eq(Ior.left(lhs0), Ior.left(rhs0))).to.equal(
-						eq(lhs0, rhs0),
-					);
-				}),
-			);
+			const property = fc.property(arbNum(), arbNum(), (lhs0, rhs0) => {
+				expect(eq(Ior.left(lhs0), Ior.left(rhs0))).to.equal(
+					eq(lhs0, rhs0),
+				);
+			});
+			fc.assert(property);
 		});
 
 		it("compares any Left and any Right as inequal", () => {
-			fc.assert(
-				fc.property(arbNum(), arbNum(), (lhs0, rhs1) => {
-					expect(eq(Ior.left(lhs0), Ior.right(rhs1))).to.be.false;
-				}),
-			);
+			const property = fc.property(arbNum(), arbNum(), (lhs0, rhs1) => {
+				expect(eq(Ior.left(lhs0), Ior.right(rhs1))).to.be.false;
+			});
+			fc.assert(property);
 		});
 
 		it("compares any Left and any Both as inequal", () => {
-			fc.assert(
-				fc.property(
-					arbNum(),
-					arbNum(),
-					arbNum(),
-					(lhs0, rhs0, rhs1) => {
-						expect(eq(Ior.left(lhs0), Ior.both(rhs0, rhs1))).to.be
-							.false;
-					},
-				),
+			const property = fc.property(
+				arbNum(),
+				arbNum(),
+				arbNum(),
+				(lhs0, rhs0, rhs1) => {
+					expect(eq(Ior.left(lhs0), Ior.both(rhs0, rhs1))).to.be
+						.false;
+				},
 			);
+			fc.assert(property);
 		});
 
 		it("compares any Right and any Left as inequal", () => {
-			fc.assert(
-				fc.property(arbNum(), arbNum(), (lhs1, rhs0) => {
-					expect(eq(Ior.right(lhs1), Ior.left(rhs0))).to.be.false;
-				}),
-			);
+			const property = fc.property(arbNum(), arbNum(), (lhs1, rhs0) => {
+				expect(eq(Ior.right(lhs1), Ior.left(rhs0))).to.be.false;
+			});
+			fc.assert(property);
 		});
 
 		it("compares the values if both variants are Right", () => {
-			fc.assert(
-				fc.property(arbNum(), arbNum(), (lhs1, rhs1) => {
-					expect(eq(Ior.right(lhs1), Ior.right(rhs1))).to.equal(
-						eq(lhs1, rhs1),
-					);
-				}),
-			);
+			const property = fc.property(arbNum(), arbNum(), (lhs1, rhs1) => {
+				expect(eq(Ior.right(lhs1), Ior.right(rhs1))).to.equal(
+					eq(lhs1, rhs1),
+				);
+			});
+			fc.assert(property);
 		});
 
 		it("compares any Right and any Both as inequal", () => {
-			fc.assert(
-				fc.property(
-					arbNum(),
-					arbNum(),
-					arbNum(),
-					(lhs1, rhs0, rhs1) => {
-						expect(eq(Ior.right(lhs1), Ior.both(rhs0, rhs1))).to.be
-							.false;
-					},
-				),
+			const property = fc.property(
+				arbNum(),
+				arbNum(),
+				arbNum(),
+				(lhs1, rhs0, rhs1) => {
+					expect(eq(Ior.right(lhs1), Ior.both(rhs0, rhs1))).to.be
+						.false;
+				},
 			);
+			fc.assert(property);
 		});
 
 		it("compares any Both and any Left as inequal", () => {
-			fc.assert(
-				fc.property(
-					arbNum(),
-					arbNum(),
-					arbNum(),
-					(lhs0, lhs1, rhs0) => {
-						expect(eq(Ior.both(lhs0, lhs1), Ior.left(rhs0))).to.be
-							.false;
-					},
-				),
+			const property = fc.property(
+				arbNum(),
+				arbNum(),
+				arbNum(),
+				(lhs0, lhs1, rhs0) => {
+					expect(eq(Ior.both(lhs0, lhs1), Ior.left(rhs0))).to.be
+						.false;
+				},
 			);
+			fc.assert(property);
 		});
 
 		it("compares any Both and any Right as inequal", () => {
-			fc.assert(
-				fc.property(
-					arbNum(),
-					arbNum(),
-					arbNum(),
-					(lhs0, lhs1, rhs1) => {
-						expect(eq(Ior.both(lhs0, lhs1), Ior.right(rhs1))).to.be
-							.false;
-					},
-				),
+			const property = fc.property(
+				arbNum(),
+				arbNum(),
+				arbNum(),
+				(lhs0, lhs1, rhs1) => {
+					expect(eq(Ior.both(lhs0, lhs1), Ior.right(rhs1))).to.be
+						.false;
+				},
 			);
+			fc.assert(property);
 		});
 
 		it("compares the left-hand values and the right-hand values lexicographically if both variants are Both", () => {
-			fc.assert(
-				fc.property(
-					arbNum(),
-					arbNum(),
-					arbNum(),
-					arbNum(),
-					(lhs0, lhs1, rhs0, rhs1) => {
-						expect(
-							eq(Ior.both(lhs0, lhs1), Ior.both(rhs0, rhs1)),
-						).to.equal(eq(lhs0, rhs0) && eq(lhs1, rhs1));
-					},
-				),
+			const property = fc.property(
+				arbNum(),
+				arbNum(),
+				arbNum(),
+				arbNum(),
+				(lhs0, lhs1, rhs0, rhs1) => {
+					expect(
+						eq(Ior.both(lhs0, lhs1), Ior.both(rhs0, rhs1)),
+					).to.equal(eq(lhs0, rhs0) && eq(lhs1, rhs1));
+				},
 			);
+			fc.assert(property);
 		});
 
 		it("implements a lawful equivalence relation", () => {
@@ -493,119 +484,110 @@ describe("Ior", () => {
 
 	describe("#[Ord.cmp]", () => {
 		it("compares the values if both variants are Left", () => {
-			fc.assert(
-				fc.property(arbNum(), arbNum(), (lhs0, rhs0) => {
-					expect(cmp(Ior.left(lhs0), Ior.left(rhs0))).to.equal(
-						cmp(lhs0, rhs0),
-					);
-				}),
-			);
+			const property = fc.property(arbNum(), arbNum(), (lhs0, rhs0) => {
+				expect(cmp(Ior.left(lhs0), Ior.left(rhs0))).to.equal(
+					cmp(lhs0, rhs0),
+				);
+			});
+			fc.assert(property);
 		});
 
 		it("compares any Left as less than any Right", () => {
-			fc.assert(
-				fc.property(arbNum(), arbNum(), (lhs0, rhs1) => {
-					expect(cmp(Ior.left(lhs0), Ior.right(rhs1))).to.equal(
-						Ordering.less,
-					);
-				}),
-			);
+			const property = fc.property(arbNum(), arbNum(), (lhs0, rhs1) => {
+				expect(cmp(Ior.left(lhs0), Ior.right(rhs1))).to.equal(
+					Ordering.less,
+				);
+			});
+			fc.assert(property);
 		});
 
 		it("compares any Left as less than any Both", () => {
-			fc.assert(
-				fc.property(
-					arbNum(),
-					arbNum(),
-					arbNum(),
-					(lhs0, rhs0, rhs1) => {
-						expect(
-							cmp(Ior.left(lhs0), Ior.both(rhs0, rhs1)),
-						).to.equal(Ordering.less);
-					},
-				),
+			const property = fc.property(
+				arbNum(),
+				arbNum(),
+				arbNum(),
+				(lhs0, rhs0, rhs1) => {
+					expect(cmp(Ior.left(lhs0), Ior.both(rhs0, rhs1))).to.equal(
+						Ordering.less,
+					);
+				},
 			);
+			fc.assert(property);
 		});
 
 		it("compares any Right as greater than any Left", () => {
-			fc.assert(
-				fc.property(arbNum(), arbNum(), (lhs1, rhs0) => {
-					expect(cmp(Ior.right(lhs1), Ior.left(rhs0))).to.equal(
-						Ordering.greater,
-					);
-				}),
-			);
+			const property = fc.property(arbNum(), arbNum(), (lhs1, rhs0) => {
+				expect(cmp(Ior.right(lhs1), Ior.left(rhs0))).to.equal(
+					Ordering.greater,
+				);
+			});
+			fc.assert(property);
 		});
 
 		it("compares the values if both variants are Right", () => {
-			fc.assert(
-				fc.property(arbNum(), arbNum(), (lhs1, rhs1) => {
-					expect(cmp(Ior.right(lhs1), Ior.right(rhs1))).to.equal(
-						cmp(lhs1, rhs1),
-					);
-				}),
-			);
+			const property = fc.property(arbNum(), arbNum(), (lhs1, rhs1) => {
+				expect(cmp(Ior.right(lhs1), Ior.right(rhs1))).to.equal(
+					cmp(lhs1, rhs1),
+				);
+			});
+			fc.assert(property);
 		});
 
 		it("compares any Right as less than any Both", () => {
-			fc.assert(
-				fc.property(
-					arbNum(),
-					arbNum(),
-					arbNum(),
-					(lhs1, rhs0, rhs1) => {
-						expect(
-							cmp(Ior.right(lhs1), Ior.both(rhs0, rhs1)),
-						).to.equal(Ordering.less);
-					},
-				),
+			const property = fc.property(
+				arbNum(),
+				arbNum(),
+				arbNum(),
+				(lhs1, rhs0, rhs1) => {
+					expect(cmp(Ior.right(lhs1), Ior.both(rhs0, rhs1))).to.equal(
+						Ordering.less,
+					);
+				},
 			);
+			fc.assert(property);
 		});
 
 		it("compares any Both as greater than any Left", () => {
-			fc.assert(
-				fc.property(
-					arbNum(),
-					arbNum(),
-					arbNum(),
-					(lhs0, lhs1, rhs0) => {
-						expect(
-							cmp(Ior.both(lhs0, lhs1), Ior.left(rhs0)),
-						).to.equal(Ordering.greater);
-					},
-				),
+			const property = fc.property(
+				arbNum(),
+				arbNum(),
+				arbNum(),
+				(lhs0, lhs1, rhs0) => {
+					expect(cmp(Ior.both(lhs0, lhs1), Ior.left(rhs0))).to.equal(
+						Ordering.greater,
+					);
+				},
 			);
+			fc.assert(property);
 		});
 
 		it("compares any Both as greater than any Right", () => {
-			fc.assert(
-				fc.property(
-					arbNum(),
-					arbNum(),
-					arbNum(),
-					(lhs0, lhs1, rhs1) => {
-						expect(
-							cmp(Ior.both(lhs0, lhs1), Ior.right(rhs1)),
-						).to.equal(Ordering.greater);
-					},
-				),
+			const property = fc.property(
+				arbNum(),
+				arbNum(),
+				arbNum(),
+				(lhs0, lhs1, rhs1) => {
+					expect(cmp(Ior.both(lhs0, lhs1), Ior.right(rhs1))).to.equal(
+						Ordering.greater,
+					);
+				},
 			);
+			fc.assert(property);
 		});
 
 		it("compares the left-hand values and the right-hand values lexicographically if both variants are Both", () => {
-			fc.assert(
-				fc.property(
-					arbNum(),
-					arbNum(),
-					arbNum(),
-					arbNum(),
-					(lhs0, lhs1, rhs0, rhs1) => {
-						expect(
-							cmp(Ior.both(lhs0, lhs1), Ior.both(rhs0, rhs1)),
-						).to.equal(cmb(cmp(lhs0, rhs0), cmp(lhs1, rhs1)));
-					},
-				),
+			const property = fc.property(
+				arbNum(),
+				arbNum(),
+				arbNum(),
+				arbNum(),
+				(lhs0, lhs1, rhs0, rhs1) => {
+					expect(
+						cmp(Ior.both(lhs0, lhs1), Ior.both(rhs0, rhs1)),
+					).to.equal(cmb(cmp(lhs0, rhs0), cmp(lhs1, rhs1)));
+				},
 			);
+			fc.assert(property);
 		});
 
 		it("implements a lawful total order", () => {
@@ -615,121 +597,110 @@ describe("Ior", () => {
 
 	describe("#[Semigroup.cmb]", () => {
 		it("combines the values if both variants are Left", () => {
-			fc.assert(
-				fc.property(arbStr(), arbStr(), (lhs0, rhs0) => {
-					expect(cmb(Ior.left(lhs0), Ior.left(rhs0))).to.deep.equal(
-						Ior.left(cmb(lhs0, rhs0)),
-					);
-				}),
-			);
+			const property = fc.property(arbStr(), arbStr(), (lhs0, rhs0) => {
+				expect(cmb(Ior.left(lhs0), Ior.left(rhs0))).to.deep.equal(
+					Ior.left(cmb(lhs0, rhs0)),
+				);
+			});
+			fc.assert(property);
 		});
 
 		it("merges the values into a Both if the variants are Left and Right", () => {
-			fc.assert(
-				fc.property(arbStr(), arbStr(), (lhs0, rhs1) => {
-					expect(cmb(Ior.left(lhs0), Ior.right(rhs1))).to.deep.equal(
-						Ior.both(lhs0, rhs1),
-					);
-				}),
-			);
+			const property = fc.property(arbStr(), arbStr(), (lhs0, rhs1) => {
+				expect(cmb(Ior.left(lhs0), Ior.right(rhs1))).to.deep.equal(
+					Ior.both(lhs0, rhs1),
+				);
+			});
+			fc.assert(property);
 		});
 
 		it("combines the left-hand values and retains the right-hand value if the variants are Left and Both", () => {
-			fc.assert(
-				fc.property(
-					arbStr(),
-					arbStr(),
-					arbStr(),
-					(lhs0, rhs0, rhs1) => {
-						expect(
-							cmb(Ior.left(lhs0), Ior.both(rhs0, rhs1)),
-						).to.deep.equal(Ior.both(cmb(lhs0, rhs0), rhs1));
-					},
-				),
+			const property = fc.property(
+				arbStr(),
+				arbStr(),
+				arbStr(),
+				(lhs0, rhs0, rhs1) => {
+					expect(
+						cmb(Ior.left(lhs0), Ior.both(rhs0, rhs1)),
+					).to.deep.equal(Ior.both(cmb(lhs0, rhs0), rhs1));
+				},
 			);
+			fc.assert(property);
 		});
 
 		it("merges the values into a Both if the variants are Right and Left", () => {
-			fc.assert(
-				fc.property(arbStr(), arbStr(), (lhs1, rhs0) => {
-					expect(cmb(Ior.right(lhs1), Ior.left(rhs0))).to.deep.equal(
-						Ior.both(rhs0, lhs1),
-					);
-				}),
-			);
+			const property = fc.property(arbStr(), arbStr(), (lhs1, rhs0) => {
+				expect(cmb(Ior.right(lhs1), Ior.left(rhs0))).to.deep.equal(
+					Ior.both(rhs0, lhs1),
+				);
+			});
+			fc.assert(property);
 		});
 
 		it("combines the values if both variants are Right", () => {
-			fc.assert(
-				fc.property(arbStr(), arbStr(), (lhs1, rhs1) => {
-					expect(cmb(Ior.right(lhs1), Ior.right(rhs1))).to.deep.equal(
-						Ior.right(cmb(lhs1, rhs1)),
-					);
-				}),
-			);
+			const property = fc.property(arbStr(), arbStr(), (lhs1, rhs1) => {
+				expect(cmb(Ior.right(lhs1), Ior.right(rhs1))).to.deep.equal(
+					Ior.right(cmb(lhs1, rhs1)),
+				);
+			});
+			fc.assert(property);
 		});
 
 		it("retains the left-hand value and combines the right-hand values if the variants are Right and Both", () => {
-			fc.assert(
-				fc.property(
-					arbStr(),
-					arbStr(),
-					arbStr(),
-					(lhs1, rhs0, rhs1) => {
-						expect(
-							cmb(Ior.right(lhs1), Ior.both(rhs0, rhs1)),
-						).to.deep.equal(Ior.both(rhs0, cmb(lhs1, rhs1)));
-					},
-				),
+			const property = fc.property(
+				arbStr(),
+				arbStr(),
+				arbStr(),
+				(lhs1, rhs0, rhs1) => {
+					expect(
+						cmb(Ior.right(lhs1), Ior.both(rhs0, rhs1)),
+					).to.deep.equal(Ior.both(rhs0, cmb(lhs1, rhs1)));
+				},
 			);
+			fc.assert(property);
 		});
 
 		it("combines the left-hand values and retains the right-hand value if the variants are Both and Left", () => {
-			fc.assert(
-				fc.property(
-					arbStr(),
-					arbStr(),
-					arbStr(),
-					(lhs0, lhs1, rhs0) => {
-						expect(
-							cmb(Ior.both(lhs0, lhs1), Ior.left(rhs0)),
-						).to.deep.equal(Ior.both(cmb(lhs0, rhs0), lhs1));
-					},
-				),
+			const property = fc.property(
+				arbStr(),
+				arbStr(),
+				arbStr(),
+				(lhs0, lhs1, rhs0) => {
+					expect(
+						cmb(Ior.both(lhs0, lhs1), Ior.left(rhs0)),
+					).to.deep.equal(Ior.both(cmb(lhs0, rhs0), lhs1));
+				},
 			);
+			fc.assert(property);
 		});
 
 		it("retains the left-hand value and combines the right-hand values if the variants are Both and Right", () => {
-			fc.assert(
-				fc.property(
-					arbStr(),
-					arbStr(),
-					arbStr(),
-					(lhs0, lhs1, rhs1) => {
-						expect(
-							cmb(Ior.both(lhs0, lhs1), Ior.right(rhs1)),
-						).to.deep.equal(Ior.both(lhs0, cmb(lhs1, rhs1)));
-					},
-				),
+			const property = fc.property(
+				arbStr(),
+				arbStr(),
+				arbStr(),
+				(lhs0, lhs1, rhs1) => {
+					expect(
+						cmb(Ior.both(lhs0, lhs1), Ior.right(rhs1)),
+					).to.deep.equal(Ior.both(lhs0, cmb(lhs1, rhs1)));
+				},
 			);
+			fc.assert(property);
 		});
 
 		it("combines the left-hand values and the right-hand values pairwise if both variants are Both", () => {
-			fc.assert(
-				fc.property(
-					arbStr(),
-					arbStr(),
-					arbStr(),
-					arbStr(),
-					(lhs0, lhs1, rhs0, rhs1) => {
-						expect(
-							cmb(Ior.both(lhs0, lhs1), Ior.both(rhs0, rhs1)),
-						).to.deep.equal(
-							Ior.both(cmb(lhs0, rhs0), cmb(lhs1, rhs1)),
-						);
-					},
-				),
+			const property = fc.property(
+				arbStr(),
+				arbStr(),
+				arbStr(),
+				arbStr(),
+				(lhs0, lhs1, rhs0, rhs1) => {
+					expect(
+						cmb(Ior.both(lhs0, lhs1), Ior.both(rhs0, rhs1)),
+					).to.deep.equal(Ior.both(cmb(lhs0, rhs0), cmb(lhs1, rhs1)));
+				},
 			);
+			fc.assert(property);
 		});
 
 		it("implements a lawful semigroup", () => {

--- a/src/ior.test.ts
+++ b/src/ior.test.ts
@@ -38,7 +38,7 @@ describe("Ior", () => {
 		return fc.oneof(
 			arbLeft.map(Ior.left),
 			arbRight.map(Ior.right),
-			arbLeft.chain((x) => arbRight.map((y) => Ior.both(x, y))),
+			arbLeft.chain((fst) => arbRight.map((snd) => Ior.both(fst, snd))),
 		);
 	}
 
@@ -97,81 +97,70 @@ describe("Ior", () => {
 
 	describe("go", () => {
 		it("short-circuits on the first yielded Left", () => {
-			function* f(): Ior.Go<Str, [2, 2, 4]> {
-				const x = yield* Ior.right<2, Str>(2);
-				expect(x).to.equal(2);
-				const [y, z] = yield* Ior.left<Str, [2, 4]>(new Str("b"));
-				return [x, y, z];
+			function* f(): Ior.Go<Str, [2, 4]> {
+				const two = yield* Ior.right<2, Str>(2);
+				const four = yield* Ior.left<Str, 4>(new Str("b"));
+				return [two, four];
 			}
 			const ior = Ior.go(f());
 			expect(ior).to.deep.equal(Ior.left(new Str("b")));
 		});
 
 		it("completes if all yielded values are Right", () => {
-			function* f(): Ior.Go<Str, [2, 2, 4]> {
-				const x = yield* Ior.right<2, Str>(2);
-				const [y, z] = yield* Ior.right<[2, 4], Str>([x, 4]);
-				return [x, y, z];
+			function* f(): Ior.Go<Str, [2, 4]> {
+				const two = yield* Ior.right<2, Str>(2);
+				const four = yield* Ior.right<4, Str>(4);
+				return [two, four];
 			}
 			const ior = Ior.go(f());
-			expect(ior).to.deep.equal(Ior.right([2, 2, 4]));
+			expect(ior).to.deep.equal(Ior.right([2, 4]));
 		});
 
 		it("completes and retains the left-hand value if a Both is yielded after a Right", () => {
-			function* f(): Ior.Go<Str, [2, 2, 4]> {
-				const x = yield* Ior.right<2, Str>(2);
-				const [y, z] = yield* Ior.both<Str, [2, 4]>(new Str("b"), [
-					x,
-					4,
-				]);
-				return [x, y, z];
+			function* f(): Ior.Go<Str, [2, 4]> {
+				const two = yield* Ior.right<2, Str>(2);
+				const four = yield* Ior.both<Str, 4>(new Str("b"), 4);
+				return [two, four];
 			}
 			const ior = Ior.go(f());
-			expect(ior).to.deep.equal(Ior.both(new Str("b"), [2, 2, 4]));
+			expect(ior).to.deep.equal(Ior.both(new Str("b"), [2, 4]));
 		});
 
 		it("short-circuits and combines the left-hand values if a Left is yielded after a Both", () => {
-			function* f(): Ior.Go<Str, [2, 2, 4]> {
-				const x = yield* Ior.both<Str, 2>(new Str("a"), 2);
-				expect(x).to.equal(2);
-				const [y, z] = yield* Ior.left<Str, [2, 4]>(new Str("b"));
-				return [x, y, z];
+			function* f(): Ior.Go<Str, [2, 4]> {
+				const two = yield* Ior.both<Str, 2>(new Str("a"), 2);
+				const four = yield* Ior.left<Str, 4>(new Str("b"));
+				return [two, four];
 			}
 			const ior = Ior.go(f());
 			expect(ior).to.deep.equal(Ior.left(new Str("ab")));
 		});
 
 		it("completes and retains the left-hand value if a Right is yielded after a Both", () => {
-			function* f(): Ior.Go<Str, [2, 2, 4]> {
-				const x = yield* Ior.both<Str, 2>(new Str("a"), 2);
-				const [y, z] = yield* Ior.right<[2, 4], Str>([x, 4]);
-				return [x, y, z];
+			function* f(): Ior.Go<Str, [2, 4]> {
+				const two = yield* Ior.both<Str, 2>(new Str("a"), 2);
+				const four = yield* Ior.right<4, Str>(4);
+				return [two, four];
 			}
 			const ior = Ior.go(f());
-			expect(ior).to.deep.equal(Ior.both(new Str("a"), [2, 2, 4]));
+			expect(ior).to.deep.equal(Ior.both(new Str("a"), [2, 4]));
 		});
 
 		it("completes and combines the left-hand values if a Both is yielded after a Both", () => {
-			function* f(): Ior.Go<Str, [2, 2, 4]> {
-				const x = yield* Ior.both<Str, 2>(new Str("a"), 2);
-				const [y, z] = yield* Ior.both<Str, [2, 4]>(new Str("b"), [
-					x,
-					4,
-				]);
-				return [x, y, z];
+			function* f(): Ior.Go<Str, [2, 4]> {
+				const two = yield* Ior.both<Str, 2>(new Str("a"), 2);
+				const four = yield* Ior.both<Str, 4>(new Str("b"), 4);
+				return [two, four];
 			}
 			const ior = Ior.go(f());
-			expect(ior).to.deep.equal(Ior.both(new Str("ab"), [2, 2, 4]));
+			expect(ior).to.deep.equal(Ior.both(new Str("ab"), [2, 4]));
 		});
 
 		it("executes the finally block if a Left is yielded in the try block", () => {
 			const logs: string[] = [];
-			function* f(): Ior.Go<Str, number[]> {
+			function* f(): Ior.Go<Str, 2> {
 				try {
-					const results = [];
-					const x = yield* Ior.left<Str, 2>(new Str("a"));
-					results.push(x);
-					return results;
+					return yield* Ior.left<Str, 2>(new Str("a"));
 				} finally {
 					logs.push("finally");
 				}
@@ -182,12 +171,9 @@ describe("Ior", () => {
 		});
 
 		it("combines the left-hand values of two Left variants across the try...finally block", () => {
-			function* f(): Ior.Go<Str, number[]> {
+			function* f(): Ior.Go<Str, 2> {
 				try {
-					const results = [];
-					const x = yield* Ior.left<Str, 2>(new Str("a"));
-					results.push(x);
-					return results;
+					return yield* Ior.left<Str, 2>(new Str("a"));
 				} finally {
 					yield* Ior.left<Str, 4>(new Str("b"));
 				}
@@ -197,12 +183,9 @@ describe("Ior", () => {
 		});
 
 		it("combines the left-hand values of a Left variant and a Both variant across the try...finally block", () => {
-			function* f(): Ior.Go<Str, number[]> {
+			function* f(): Ior.Go<Str, 2> {
 				try {
-					const results = [];
-					const x = yield* Ior.left<Str, 2>(new Str("a"));
-					results.push(x);
-					return results;
+					return yield* Ior.left<Str, 2>(new Str("a"));
 				} finally {
 					yield* Ior.both<Str, 4>(new Str("b"), 4);
 				}
@@ -216,7 +199,7 @@ describe("Ior", () => {
 		it("reduces the finite iterable from left to right in the context of Ior", () => {
 			const ior = Ior.reduce(
 				["x", "y"],
-				(xs, x) => Ior.both(new Str("a"), xs + x),
+				(chars, char) => Ior.both(new Str("a"), chars + char),
 				"",
 			);
 			expect(ior).to.deep.equal(Ior.both(new Str("aa"), "xy"));
@@ -236,10 +219,12 @@ describe("Ior", () => {
 	describe("allProps", () => {
 		it("turns the record or the object literal of Ior elements inside out", () => {
 			const ior = Ior.allProps({
-				x: Ior.both<Str, 2>(new Str("a"), 2),
-				y: Ior.both<Str, 4>(new Str("b"), 4),
+				two: Ior.both<Str, 2>(new Str("a"), 2),
+				four: Ior.both<Str, 4>(new Str("b"), 4),
 			});
-			expect(ior).to.deep.equal(Ior.both(new Str("ab"), { x: 2, y: 4 }));
+			expect(ior).to.deep.equal(
+				Ior.both(new Str("ab"), { two: 2, four: 4 }),
+			);
 		});
 	});
 
@@ -258,109 +243,100 @@ describe("Ior", () => {
 
 	describe("goAsync", async () => {
 		it("short-circuits on the first yielded Left", async () => {
-			async function* f(): Ior.GoAsync<Str, [2, 2, 4]> {
-				const x = yield* await Promise.resolve(Ior.right<2, Str>(2));
-				expect(x).to.equal(2);
-				const [y, z] = yield* await Promise.resolve(
-					Ior.left<Str, [2, 4]>(new Str("b")),
+			async function* f(): Ior.GoAsync<Str, [2, 4]> {
+				const two = yield* await Promise.resolve(Ior.right<2, Str>(2));
+				const four = yield* await Promise.resolve(
+					Ior.left<Str, 4>(new Str("b")),
 				);
-				return [x, y, z];
+				return [two, four];
 			}
 			const ior = await Ior.goAsync(f());
 			expect(ior).to.deep.equal(Ior.left(new Str("b")));
 		});
 
 		it("completes if all yielded values are Right", async () => {
-			async function* f(): Ior.GoAsync<Str, [2, 2, 4]> {
-				const x = yield* await Promise.resolve(Ior.right<2, Str>(2));
-				const [y, z] = yield* await Promise.resolve(
-					Ior.right<[2, 4], Str>([x, 4]),
-				);
-				return [x, y, z];
+			async function* f(): Ior.GoAsync<Str, [2, 4]> {
+				const two = yield* await Promise.resolve(Ior.right<2, Str>(2));
+				const four = yield* await Promise.resolve(Ior.right<4, Str>(4));
+				return [two, four];
 			}
 			const ior = await Ior.goAsync(f());
-			expect(ior).to.deep.equal(Ior.right([2, 2, 4]));
+			expect(ior).to.deep.equal(Ior.right([2, 4]));
 		});
 
 		it("completes and retains the left-hand value if a Both is yielded after a Right", async () => {
-			async function* f(): Ior.GoAsync<Str, [2, 2, 4]> {
-				const x = yield* await Promise.resolve(Ior.right<2, Str>(2));
-				const [y, z] = yield* await Promise.resolve(
-					Ior.both<Str, [2, 4]>(new Str("b"), [x, 4]),
+			async function* f(): Ior.GoAsync<Str, [2, 4]> {
+				const two = yield* await Promise.resolve(Ior.right<2, Str>(2));
+				const four = yield* await Promise.resolve(
+					Ior.both<Str, 4>(new Str("b"), 4),
 				);
-				return [x, y, z];
+				return [two, four];
 			}
 			const ior = await Ior.goAsync(f());
-			expect(ior).to.deep.equal(Ior.both(new Str("b"), [2, 2, 4]));
+			expect(ior).to.deep.equal(Ior.both(new Str("b"), [2, 4]));
 		});
 
 		it("short-circuits and combines the left-hand values if a Left is yielded after a Both", async () => {
-			async function* f(): Ior.GoAsync<Str, [2, 2, 4]> {
-				const x = yield* await Promise.resolve(
+			async function* f(): Ior.GoAsync<Str, [2, 4]> {
+				const two = yield* await Promise.resolve(
 					Ior.both<Str, 2>(new Str("a"), 2),
 				);
-				expect(x).to.equal(2);
-				const [y, z] = yield* await Promise.resolve(
-					Ior.left<Str, [2, 4]>(new Str("b")),
+				const four = yield* await Promise.resolve(
+					Ior.left<Str, 4>(new Str("b")),
 				);
-				return [x, y, z];
+				return [two, four];
 			}
 			const ior = await Ior.goAsync(f());
 			expect(ior).to.deep.equal(Ior.left(new Str("ab")));
 		});
 
 		it("completes and retains the left-hand value if a Right is yielded after a Both", async () => {
-			async function* f(): Ior.GoAsync<Str, [2, 2, 4]> {
-				const x = yield* await Promise.resolve(
+			async function* f(): Ior.GoAsync<Str, [2, 4]> {
+				const two = yield* await Promise.resolve(
 					Ior.both<Str, 2>(new Str("a"), 2),
 				);
-				const [y, z] = yield* await Promise.resolve(
-					Ior.right<[2, 4], Str>([x, 4]),
-				);
-				return [x, y, z];
+				const four = yield* await Promise.resolve(Ior.right<4, Str>(4));
+				return [two, four];
 			}
 			const ior = await Ior.goAsync(f());
-			expect(ior).to.deep.equal(Ior.both(new Str("a"), [2, 2, 4]));
+			expect(ior).to.deep.equal(Ior.both(new Str("a"), [2, 4]));
 		});
 
 		it("completes and combines the left-hand values if a Both is yielded after", async () => {
-			async function* f(): Ior.GoAsync<Str, [2, 2, 4]> {
-				const x = yield* await Promise.resolve(
+			async function* f(): Ior.GoAsync<Str, [2, 4]> {
+				const two = yield* await Promise.resolve(
 					Ior.both<Str, 2>(new Str("a"), 2),
 				);
-				const [y, z] = yield* await Promise.resolve(
-					Ior.both<Str, [2, 4]>(new Str("b"), [x, 4]),
+				const four = yield* await Promise.resolve(
+					Ior.both<Str, 4>(new Str("b"), 4),
 				);
-				return [x, y, z];
+				return [two, four];
 			}
 			const ior = await Ior.goAsync(f());
-			expect(ior).to.deep.equal(Ior.both(new Str("ab"), [2, 2, 4]));
+			expect(ior).to.deep.equal(Ior.both(new Str("ab"), [2, 4]));
 		});
 
 		it("unwraps Promises in right-hand channels and in return", async () => {
-			async function* f(): Ior.GoAsync<Str, [2, 2, 4]> {
-				const x = yield* await Promise.resolve(
-					Ior.both<Str, Promise<2>>(new Str("a"), Promise.resolve(2)),
+			async function* f(): Ior.GoAsync<Str, [2, 4]> {
+				const two = yield* await Promise.resolve(
+					Ior.both(new Str("a"), Promise.resolve<2>(2)),
 				);
-				const [y, z] = yield* await Promise.resolve(
-					Ior.both(new Str("b"), Promise.resolve<[2, 4]>([x, 4])),
+				const four = yield* await Promise.resolve(
+					Ior.both(new Str("b"), Promise.resolve<4>(4)),
 				);
-				return Promise.resolve([x, y, z]);
+				return Promise.resolve([two, four]);
 			}
 			const ior = await Ior.goAsync(f());
-			expect(ior).to.deep.equal(Ior.both(new Str("ab"), [2, 2, 4]));
+			expect(ior).to.deep.equal(Ior.both(new Str("ab"), [2, 4]));
 		});
 
 		it("executes the finally block if a Left is yielded in the try block", async () => {
 			const logs: string[] = [];
-			async function* f(): Ior.GoAsync<Str, number[]> {
+			async function* f(): Ior.GoAsync<Str, 2> {
 				try {
-					const results = [];
-					const x = yield* await Promise.resolve(
+					return yield* await Promise.resolve(
 						Ior.left<Str, 2>(new Str("a")),
 					);
-					results.push(x);
-					return results;
 				} finally {
 					logs.push("finally");
 				}
@@ -371,14 +347,11 @@ describe("Ior", () => {
 		});
 
 		it("combines the left-hand values of two Left variants across the try...finally block", async () => {
-			async function* f(): Ior.GoAsync<Str, number[]> {
+			async function* f(): Ior.GoAsync<Str, 2> {
 				try {
-					const results = [];
-					const x = yield* await Promise.resolve(
+					return yield* await Promise.resolve(
 						Ior.left<Str, 2>(new Str("a")),
 					);
-					results.push(x);
-					return results;
 				} finally {
 					yield* Ior.left<Str, 4>(new Str("b"));
 				}
@@ -388,14 +361,11 @@ describe("Ior", () => {
 		});
 
 		it("combines the left-hand values of a Left variant and a Both variant across the try...finally block", async () => {
-			async function* f(): Ior.GoAsync<Str, number[]> {
+			async function* f(): Ior.GoAsync<Str, 2> {
 				try {
-					const results = [];
-					const x = yield* await Promise.resolve(
+					return yield* await Promise.resolve(
 						Ior.left<Str, 2>(new Str("a")),
 					);
-					results.push(x);
-					return results;
 				} finally {
 					yield* await Promise.resolve(
 						Ior.both<Str, 4>(new Str("b"), 4),
@@ -410,65 +380,93 @@ describe("Ior", () => {
 	describe("#[Eq.eq]", () => {
 		it("compares the values if both variants are Left", () => {
 			fc.assert(
-				fc.property(arbNum(), arbNum(), (a, b) => {
-					expect(eq(Ior.left(a), Ior.left(b))).to.equal(eq(a, b));
+				fc.property(arbNum(), arbNum(), (lhs0, rhs0) => {
+					expect(eq(Ior.left(lhs0), Ior.left(rhs0))).to.equal(
+						eq(lhs0, rhs0),
+					);
 				}),
 			);
 		});
 
 		it("compares any Left and any Right as inequal", () => {
 			fc.assert(
-				fc.property(arbNum(), arbNum(), (a, y) => {
-					expect(eq(Ior.left(a), Ior.right(y))).to.be.false;
+				fc.property(arbNum(), arbNum(), (lhs0, rhs1) => {
+					expect(eq(Ior.left(lhs0), Ior.right(rhs1))).to.be.false;
 				}),
 			);
 		});
 
 		it("compares any Left and any Both as inequal", () => {
 			fc.assert(
-				fc.property(arbNum(), arbNum(), arbNum(), (a, b, y) => {
-					expect(eq(Ior.left(a), Ior.both(b, y))).to.be.false;
-				}),
+				fc.property(
+					arbNum(),
+					arbNum(),
+					arbNum(),
+					(lhs0, rhs0, rhs1) => {
+						expect(eq(Ior.left(lhs0), Ior.both(rhs0, rhs1))).to.be
+							.false;
+					},
+				),
 			);
 		});
 
 		it("compares any Right and any Left as inequal", () => {
 			fc.assert(
-				fc.property(arbNum(), arbNum(), (x, b) => {
-					expect(eq(Ior.right(x), Ior.left(b))).to.be.false;
+				fc.property(arbNum(), arbNum(), (lhs1, rhs0) => {
+					expect(eq(Ior.right(lhs1), Ior.left(rhs0))).to.be.false;
 				}),
 			);
 		});
 
 		it("compares the values if both variants are Right", () => {
 			fc.assert(
-				fc.property(arbNum(), arbNum(), (x, y) => {
-					expect(eq(Ior.right(x), Ior.right(y))).to.equal(eq(x, y));
+				fc.property(arbNum(), arbNum(), (lhs1, rhs1) => {
+					expect(eq(Ior.right(lhs1), Ior.right(rhs1))).to.equal(
+						eq(lhs1, rhs1),
+					);
 				}),
 			);
 		});
 
 		it("compares any Right and any Both as inequal", () => {
 			fc.assert(
-				fc.property(arbNum(), arbNum(), arbNum(), (x, b, y) => {
-					expect(eq(Ior.right(x), Ior.both(b, y))).to.be.false;
-				}),
+				fc.property(
+					arbNum(),
+					arbNum(),
+					arbNum(),
+					(lhs1, rhs0, rhs1) => {
+						expect(eq(Ior.right(lhs1), Ior.both(rhs0, rhs1))).to.be
+							.false;
+					},
+				),
 			);
 		});
 
 		it("compares any Both and any Left as inequal", () => {
 			fc.assert(
-				fc.property(arbNum(), arbNum(), arbNum(), (a, x, b) => {
-					expect(eq(Ior.both(a, x), Ior.left(b))).to.be.false;
-				}),
+				fc.property(
+					arbNum(),
+					arbNum(),
+					arbNum(),
+					(lhs0, lhs1, rhs0) => {
+						expect(eq(Ior.both(lhs0, lhs1), Ior.left(rhs0))).to.be
+							.false;
+					},
+				),
 			);
 		});
 
 		it("compares any Both and any Right as inequal", () => {
 			fc.assert(
-				fc.property(arbNum(), arbNum(), arbNum(), (a, x, y) => {
-					expect(eq(Ior.both(a, x), Ior.right(y))).to.be.false;
-				}),
+				fc.property(
+					arbNum(),
+					arbNum(),
+					arbNum(),
+					(lhs0, lhs1, rhs1) => {
+						expect(eq(Ior.both(lhs0, lhs1), Ior.right(rhs1))).to.be
+							.false;
+					},
+				),
 			);
 		});
 
@@ -479,10 +477,10 @@ describe("Ior", () => {
 					arbNum(),
 					arbNum(),
 					arbNum(),
-					(a, x, b, y) => {
-						expect(eq(Ior.both(a, x), Ior.both(b, y))).to.equal(
-							eq(a, b) && eq(x, y),
-						);
+					(lhs0, lhs1, rhs0, rhs1) => {
+						expect(
+							eq(Ior.both(lhs0, lhs1), Ior.both(rhs0, rhs1)),
+						).to.equal(eq(lhs0, rhs0) && eq(lhs1, rhs1));
 					},
 				),
 			);
@@ -496,16 +494,18 @@ describe("Ior", () => {
 	describe("#[Ord.cmp]", () => {
 		it("compares the values if both variants are Left", () => {
 			fc.assert(
-				fc.property(arbNum(), arbNum(), (a, b) => {
-					expect(cmp(Ior.left(a), Ior.left(b))).to.equal(cmp(a, b));
+				fc.property(arbNum(), arbNum(), (lhs0, rhs0) => {
+					expect(cmp(Ior.left(lhs0), Ior.left(rhs0))).to.equal(
+						cmp(lhs0, rhs0),
+					);
 				}),
 			);
 		});
 
 		it("compares any Left as less than any Right", () => {
 			fc.assert(
-				fc.property(arbNum(), arbNum(), (a, y) => {
-					expect(cmp(Ior.left(a), Ior.right(y))).to.equal(
+				fc.property(arbNum(), arbNum(), (lhs0, rhs1) => {
+					expect(cmp(Ior.left(lhs0), Ior.right(rhs1))).to.equal(
 						Ordering.less,
 					);
 				}),
@@ -514,18 +514,23 @@ describe("Ior", () => {
 
 		it("compares any Left as less than any Both", () => {
 			fc.assert(
-				fc.property(arbNum(), arbNum(), arbNum(), (a, b, y) => {
-					expect(cmp(Ior.left(a), Ior.both(b, y))).to.equal(
-						Ordering.less,
-					);
-				}),
+				fc.property(
+					arbNum(),
+					arbNum(),
+					arbNum(),
+					(lhs0, rhs0, rhs1) => {
+						expect(
+							cmp(Ior.left(lhs0), Ior.both(rhs0, rhs1)),
+						).to.equal(Ordering.less);
+					},
+				),
 			);
 		});
 
 		it("compares any Right as greater than any Left", () => {
 			fc.assert(
-				fc.property(arbNum(), arbNum(), (x, b) => {
-					expect(cmp(Ior.right(x), Ior.left(b))).to.equal(
+				fc.property(arbNum(), arbNum(), (lhs1, rhs0) => {
+					expect(cmp(Ior.right(lhs1), Ior.left(rhs0))).to.equal(
 						Ordering.greater,
 					);
 				}),
@@ -534,39 +539,56 @@ describe("Ior", () => {
 
 		it("compares the values if both variants are Right", () => {
 			fc.assert(
-				fc.property(arbNum(), arbNum(), (x, y) => {
-					expect(cmp(Ior.right(x), Ior.right(y))).to.equal(cmp(x, y));
+				fc.property(arbNum(), arbNum(), (lhs1, rhs1) => {
+					expect(cmp(Ior.right(lhs1), Ior.right(rhs1))).to.equal(
+						cmp(lhs1, rhs1),
+					);
 				}),
 			);
 		});
 
 		it("compares any Right as less than any Both", () => {
 			fc.assert(
-				fc.property(arbNum(), arbNum(), arbNum(), (x, b, y) => {
-					expect(cmp(Ior.right(x), Ior.both(b, y))).to.equal(
-						Ordering.less,
-					);
-				}),
+				fc.property(
+					arbNum(),
+					arbNum(),
+					arbNum(),
+					(lhs1, rhs0, rhs1) => {
+						expect(
+							cmp(Ior.right(lhs1), Ior.both(rhs0, rhs1)),
+						).to.equal(Ordering.less);
+					},
+				),
 			);
 		});
 
 		it("compares any Both as greater than any Left", () => {
 			fc.assert(
-				fc.property(arbNum(), arbNum(), arbNum(), (a, x, b) => {
-					expect(cmp(Ior.both(a, x), Ior.left(b))).to.equal(
-						Ordering.greater,
-					);
-				}),
+				fc.property(
+					arbNum(),
+					arbNum(),
+					arbNum(),
+					(lhs0, lhs1, rhs0) => {
+						expect(
+							cmp(Ior.both(lhs0, lhs1), Ior.left(rhs0)),
+						).to.equal(Ordering.greater);
+					},
+				),
 			);
 		});
 
 		it("compares any Both as greater than any Right", () => {
 			fc.assert(
-				fc.property(arbNum(), arbNum(), arbNum(), (a, x, y) => {
-					expect(cmp(Ior.both(a, x), Ior.right(y))).to.equal(
-						Ordering.greater,
-					);
-				}),
+				fc.property(
+					arbNum(),
+					arbNum(),
+					arbNum(),
+					(lhs0, lhs1, rhs1) => {
+						expect(
+							cmp(Ior.both(lhs0, lhs1), Ior.right(rhs1)),
+						).to.equal(Ordering.greater);
+					},
+				),
 			);
 		});
 
@@ -577,10 +599,10 @@ describe("Ior", () => {
 					arbNum(),
 					arbNum(),
 					arbNum(),
-					(a, x, b, y) => {
-						expect(cmp(Ior.both(a, x), Ior.both(b, y))).to.equal(
-							cmb(cmp(a, b), cmp(x, y)),
-						);
+					(lhs0, lhs1, rhs0, rhs1) => {
+						expect(
+							cmp(Ior.both(lhs0, lhs1), Ior.both(rhs0, rhs1)),
+						).to.equal(cmb(cmp(lhs0, rhs0), cmp(lhs1, rhs1)));
 					},
 				),
 			);
@@ -594,9 +616,9 @@ describe("Ior", () => {
 	describe("#[Semigroup.cmb]", () => {
 		it("combines the values if both variants are Left", () => {
 			fc.assert(
-				fc.property(arbStr(), arbStr(), (a, b) => {
-					expect(cmb(Ior.left(a), Ior.left(b))).to.deep.equal(
-						Ior.left(cmb(a, b)),
+				fc.property(arbStr(), arbStr(), (lhs0, rhs0) => {
+					expect(cmb(Ior.left(lhs0), Ior.left(rhs0))).to.deep.equal(
+						Ior.left(cmb(lhs0, rhs0)),
 					);
 				}),
 			);
@@ -604,9 +626,9 @@ describe("Ior", () => {
 
 		it("merges the values into a Both if the variants are Left and Right", () => {
 			fc.assert(
-				fc.property(arbStr(), arbStr(), (a, y) => {
-					expect(cmb(Ior.left(a), Ior.right(y))).to.deep.equal(
-						Ior.both(a, y),
+				fc.property(arbStr(), arbStr(), (lhs0, rhs1) => {
+					expect(cmb(Ior.left(lhs0), Ior.right(rhs1))).to.deep.equal(
+						Ior.both(lhs0, rhs1),
 					);
 				}),
 			);
@@ -614,19 +636,24 @@ describe("Ior", () => {
 
 		it("combines the left-hand values and retains the right-hand value if the variants are Left and Both", () => {
 			fc.assert(
-				fc.property(arbStr(), arbStr(), arbStr(), (a, b, y) => {
-					expect(cmb(Ior.left(a), Ior.both(b, y))).to.deep.equal(
-						Ior.both(cmb(a, b), y),
-					);
-				}),
+				fc.property(
+					arbStr(),
+					arbStr(),
+					arbStr(),
+					(lhs0, rhs0, rhs1) => {
+						expect(
+							cmb(Ior.left(lhs0), Ior.both(rhs0, rhs1)),
+						).to.deep.equal(Ior.both(cmb(lhs0, rhs0), rhs1));
+					},
+				),
 			);
 		});
 
 		it("merges the values into a Both if the variants are Right and Left", () => {
 			fc.assert(
-				fc.property(arbStr(), arbStr(), (x, b) => {
-					expect(cmb(Ior.right(x), Ior.left(b))).to.deep.equal(
-						Ior.both(b, x),
+				fc.property(arbStr(), arbStr(), (lhs1, rhs0) => {
+					expect(cmb(Ior.right(lhs1), Ior.left(rhs0))).to.deep.equal(
+						Ior.both(rhs0, lhs1),
 					);
 				}),
 			);
@@ -634,9 +661,9 @@ describe("Ior", () => {
 
 		it("combines the values if both variants are Right", () => {
 			fc.assert(
-				fc.property(arbStr(), arbStr(), (x, y) => {
-					expect(cmb(Ior.right(x), Ior.right(y))).to.deep.equal(
-						Ior.right(cmb(x, y)),
+				fc.property(arbStr(), arbStr(), (lhs1, rhs1) => {
+					expect(cmb(Ior.right(lhs1), Ior.right(rhs1))).to.deep.equal(
+						Ior.right(cmb(lhs1, rhs1)),
 					);
 				}),
 			);
@@ -644,31 +671,46 @@ describe("Ior", () => {
 
 		it("retains the left-hand value and combines the right-hand values if the variants are Right and Both", () => {
 			fc.assert(
-				fc.property(arbStr(), arbStr(), arbStr(), (x, b, y) => {
-					expect(cmb(Ior.right(x), Ior.both(b, y))).to.deep.equal(
-						Ior.both(b, cmb(x, y)),
-					);
-				}),
+				fc.property(
+					arbStr(),
+					arbStr(),
+					arbStr(),
+					(lhs1, rhs0, rhs1) => {
+						expect(
+							cmb(Ior.right(lhs1), Ior.both(rhs0, rhs1)),
+						).to.deep.equal(Ior.both(rhs0, cmb(lhs1, rhs1)));
+					},
+				),
 			);
 		});
 
 		it("combines the left-hand values and retains the right-hand value if the variants are Both and Left", () => {
 			fc.assert(
-				fc.property(arbStr(), arbStr(), arbStr(), (a, x, b) => {
-					expect(cmb(Ior.both(a, x), Ior.left(b))).to.deep.equal(
-						Ior.both(cmb(a, b), x),
-					);
-				}),
+				fc.property(
+					arbStr(),
+					arbStr(),
+					arbStr(),
+					(lhs0, lhs1, rhs0) => {
+						expect(
+							cmb(Ior.both(lhs0, lhs1), Ior.left(rhs0)),
+						).to.deep.equal(Ior.both(cmb(lhs0, rhs0), lhs1));
+					},
+				),
 			);
 		});
 
 		it("retains the left-hand value and combines the right-hand values if the variants are Both and Right", () => {
 			fc.assert(
-				fc.property(arbStr(), arbStr(), arbStr(), (a, x, y) => {
-					expect(cmb(Ior.both(a, x), Ior.right(y))).to.deep.equal(
-						Ior.both(a, cmb(x, y)),
-					);
-				}),
+				fc.property(
+					arbStr(),
+					arbStr(),
+					arbStr(),
+					(lhs0, lhs1, rhs1) => {
+						expect(
+							cmb(Ior.both(lhs0, lhs1), Ior.right(rhs1)),
+						).to.deep.equal(Ior.both(lhs0, cmb(lhs1, rhs1)));
+					},
+				),
 			);
 		});
 
@@ -679,10 +721,12 @@ describe("Ior", () => {
 					arbStr(),
 					arbStr(),
 					arbStr(),
-					(a, x, b, y) => {
+					(lhs0, lhs1, rhs0, rhs1) => {
 						expect(
-							cmb(Ior.both(a, x), Ior.both(b, y)),
-						).to.deep.equal(Ior.both(cmb(a, b), cmb(x, y)));
+							cmb(Ior.both(lhs0, lhs1), Ior.both(rhs0, rhs1)),
+						).to.deep.equal(
+							Ior.both(cmb(lhs0, rhs0), cmb(lhs1, rhs1)),
+						);
 					},
 				),
 			);
@@ -696,27 +740,27 @@ describe("Ior", () => {
 	describe("#unwrap", () => {
 		it("applies the first function to the value if the variant is Left", () => {
 			const result = Ior.left<1, 2>(1).unwrap(
-				(x): [1, 3] => [x, 3],
-				(x): [2, 4] => [x, 4],
-				(fst, snd): [1, 2] => [fst, snd],
+				(one): [1, 3] => [one, 3],
+				(two): [2, 4] => [two, 4],
+				(one, two): [1, 2] => [one, two],
 			);
 			expect(result).to.deep.equal([1, 3]);
 		});
 
 		it("applies the second function to the value if the variant is Right", () => {
 			const result = Ior.right<2, 1>(2).unwrap(
-				(x): [1, 3] => [x, 3],
-				(x): [2, 4] => [x, 4],
-				(fst, snd): [1, 2] => [fst, snd],
+				(one): [1, 3] => [one, 3],
+				(two): [2, 4] => [two, 4],
+				(one, two): [1, 2] => [one, two],
 			);
 			expect(result).to.deep.equal([2, 4]);
 		});
 
 		it("applies the third function to the left-hand value and the right-hand value if the variant is Both", () => {
 			const result = Ior.both<1, 2>(1, 2).unwrap(
-				(x): [1, 3] => [x, 3],
-				(x): [2, 4] => [x, 4],
-				(fst, snd): [1, 2] => [fst, snd],
+				(one): [1, 3] => [one, 3],
+				(two): [2, 4] => [two, 4],
+				(one, two): [1, 2] => [one, two],
 			);
 			expect(result).to.deep.equal([1, 2]);
 		});
@@ -767,45 +811,42 @@ describe("Ior", () => {
 	describe("#flatMap", () => {
 		it("does not apply the continuation if the variant is Left", () => {
 			const ior = Ior.left<Str, 2>(new Str("a")).flatMap(
-				(x): Ior<Str, [2, 4]> => Ior.both(new Str("b"), [x, 4]),
+				(two): Ior<Str, [2, 4]> => Ior.both(new Str("b"), [two, 4]),
 			);
 			expect(ior).to.deep.equal(Ior.left(new Str("a")));
 		});
 
 		it("applies the continuation to the value if the variant is Right", () => {
 			const ior = Ior.right<2, Str>(2).flatMap(
-				(x): Ior<Str, [2, 4]> => Ior.right([x, 4]),
+				(two): Ior<Str, [2, 4]> => Ior.right([two, 4]),
 			);
 			expect(ior).to.deep.equal(Ior.right([2, 4]));
 		});
 
 		it("retains the left-hand value if the continuation on a Right returns a Both", () => {
 			const ior = Ior.right<2, Str>(2).flatMap(
-				(x): Ior<Str, [2, 4]> => Ior.both(new Str("b"), [x, 4]),
+				(two): Ior<Str, [2, 4]> => Ior.both(new Str("b"), [two, 4]),
 			);
 			expect(ior).to.deep.equal(Ior.both(new Str("b"), [2, 4]));
 		});
 
 		it("combines the left-hand values if the continuation on a Both returns a Left", () => {
 			const ior = Ior.both<Str, 2>(new Str("a"), 2).flatMap(
-				(x): Ior<Str, [2, 4]> => {
-					expect(x).to.equal(2);
-					return Ior.left(new Str("b"));
-				},
+				(): Ior<Str, [2, 4]> => Ior.left(new Str("b")),
 			);
 			expect(ior).to.deep.equal(Ior.left(new Str("ab")));
 		});
 
 		it("retains the left-hand value if the continuation on a Both returns a Right", () => {
-			const ior = Ior.both<Str, 2>(new Str("a"), 2).flatMap((x) =>
-				Ior.right<[2, 4], Str>([x, 4]),
+			const ior = Ior.both<Str, 2>(new Str("a"), 2).flatMap(
+				(two): Ior<Str, [2, 4]> => Ior.right([two, 4]),
 			);
 			expect(ior).to.deep.equal(Ior.both(new Str("a"), [2, 4]));
 		});
 
 		it("combines the left-hand values if the continuation on a Both returns a Both", () => {
 			const ior = Ior.both<Str, 2>(new Str("a"), 2).flatMap(
-				(x): Ior<Str, [2, 4]> => Ior.both(new Str("b"), [x, 4]),
+				(two): Ior<Str, [2, 4]> => Ior.both(new Str("b"), [two, 4]),
 			);
 			expect(ior).to.deep.equal(Ior.both(new Str("ab"), [2, 4]));
 		});
@@ -813,50 +854,61 @@ describe("Ior", () => {
 
 	describe("#goMap", () => {
 		it("does not apply the continuation if the variant is Left", () => {
-			const ior = Ior.left<Str, 2>(new Str("a")).goMap(function* (x) {
-				const y = yield* Ior.both<Str, 4>(new Str("b"), 4);
-				return [x, y] as [2, 4];
+			const ior = Ior.left<Str, 2>(new Str("a")).goMap(function* (
+				two,
+			): Ior.Go<Str, [2, 4]> {
+				const four = yield* Ior.both<Str, 4>(new Str("b"), 4);
+				return [two, four];
 			});
 			expect(ior).to.deep.equal(Ior.left(new Str("a")));
 		});
 
 		it("applies the continuation to the value if the variant is Right", () => {
-			const ior = Ior.right<2, Str>(2).goMap(function* (x) {
-				const y = yield* Ior.right<4, Str>(4);
-				return [x, y] as [2, 4];
+			const ior = Ior.right<2, Str>(2).goMap(function* (
+				two,
+			): Ior.Go<Str, [2, 4]> {
+				const four = yield* Ior.right<4, Str>(4);
+				return [two, four];
 			});
 			expect(ior).to.deep.equal(Ior.right([2, 4]));
 		});
 
 		it("retains the left-hand value if the continuation on a Right returns a Both", () => {
-			const ior = Ior.right<2, Str>(2).goMap(function* (x) {
-				const y = yield* Ior.both<Str, 4>(new Str("b"), 4);
-				return [x, y] as [2, 4];
+			const ior = Ior.right<2, Str>(2).goMap(function* (
+				two,
+			): Ior.Go<Str, [2, 4]> {
+				const four = yield* Ior.both<Str, 4>(new Str("b"), 4);
+				return [two, four];
 			});
 			expect(ior).to.deep.equal(Ior.both(new Str("b"), [2, 4]));
 		});
 
 		it("combines the left-hand values if the continuation on a Both returns a Left", () => {
-			const ior = Ior.both<Str, 2>(new Str("a"), 2).goMap(function* (x) {
-				expect(x).to.equal(2);
-				const y = yield* Ior.left<Str, 4>(new Str("b"));
-				return [x, y] as [2, 4];
+			const ior = Ior.both<Str, 2>(new Str("a"), 2).goMap(function* (
+				two,
+			): Ior.Go<Str, [2, 4]> {
+				const four = yield* Ior.left<Str, 4>(new Str("b"));
+				return [two, four];
 			});
 			expect(ior).to.deep.equal(Ior.left(new Str("ab")));
 		});
 
 		it("retains the left-hand value if the continuation on a Both returns a Right", () => {
-			const ior = Ior.both<Str, 2>(new Str("a"), 2).goMap(function* (x) {
-				const y = yield* Ior.right<4, Str>(4);
-				return [x, y] as [2, 4];
+			const ior = Ior.both<Str, 2>(new Str("a"), 2).goMap(function* (
+				two,
+			): Ior.Go<Str, [2, 4]> {
+				const four = yield* Ior.right<4, Str>(4);
+				return [two, four];
 			});
 			expect(ior).to.deep.equal(Ior.both(new Str("a"), [2, 4]));
 		});
 
 		it("combines the left-hand values if the continuation on a Both returns a Both", () => {
-			const ior = Ior.both<Str, 2>(new Str("a"), 2).goMap(function* (x) {
-				const y = yield* Ior.both<Str, 4>(new Str("b"), 4);
-				return [x, y] as [2, 4];
+			const ior = Ior.both<Str, 2>(new Str("a"), 2).goMap(function* (
+				two,
+			): Ior.Go<Str, [2, 4]> {
+				const four = yield* Ior.both<Str, 4>(new Str("b"), 4);
+				return [two, four];
 			});
 			expect(ior).to.deep.equal(Ior.both(new Str("ab"), [2, 4]));
 		});
@@ -866,7 +918,7 @@ describe("Ior", () => {
 		it("applies the function to the right-hand values if both variants have right-hand values", () => {
 			const ior = Ior.both<Str, 2>(new Str("a"), 2).zipWith(
 				Ior.both<Str, 4>(new Str("b"), 4),
-				(lhs, rhs): [2, 4] => [lhs, rhs],
+				(two, four): [2, 4] => [two, four],
 			);
 			expect(ior).to.deep.equal(Ior.both(new Str("ab"), [2, 4]));
 		});
@@ -892,34 +944,34 @@ describe("Ior", () => {
 
 	describe("#lmap", () => {
 		it("applies the function to the value if the variant is Left", () => {
-			const ior = Ior.left<1, 2>(1).lmap((x): [1, 3] => [x, 3]);
+			const ior = Ior.left<1, 2>(1).lmap((one): [1, 3] => [one, 3]);
 			expect(ior).to.deep.equal(Ior.left([1, 3]));
 		});
 
 		it("does not apply the function if the variant is Right", () => {
-			const ior = Ior.right<2, 1>(2).lmap((x): [1, 3] => [x, 3]);
+			const ior = Ior.right<2, 1>(2).lmap((one): [1, 3] => [one, 3]);
 			expect(ior).to.deep.equal(Ior.right(2));
 		});
 
 		it("applies the function to the left-hand value if the variant is Both", () => {
-			const ior = Ior.both<1, 2>(1, 2).lmap((x): [1, 3] => [x, 3]);
+			const ior = Ior.both<1, 2>(1, 2).lmap((one): [1, 3] => [one, 3]);
 			expect(ior).to.deep.equal(Ior.both([1, 3], 2));
 		});
 	});
 
 	describe("#map", () => {
 		it("does not apply the function if the variant is Left", () => {
-			const ior = Ior.left<1, 2>(1).map((x): [2, 4] => [x, 4]);
+			const ior = Ior.left<1, 2>(1).map((two): [2, 4] => [two, 4]);
 			expect(ior).to.deep.equal(Ior.left(1));
 		});
 
 		it("applies the function to the value if the variant is Right", () => {
-			const ior = Ior.right<2, 1>(2).map((x): [2, 4] => [x, 4]);
+			const ior = Ior.right<2, 1>(2).map((two): [2, 4] => [two, 4]);
 			expect(ior).to.deep.equal(Ior.right([2, 4]));
 		});
 
 		it("applies the function to the right-hand value if the variant is Both", () => {
-			const ior = Ior.both<1, 2>(1, 2).map((x): [2, 4] => [x, 4]);
+			const ior = Ior.both<1, 2>(1, 2).map((two): [2, 4] => [two, 4]);
 			expect(ior).to.deep.equal(Ior.both(1, [2, 4]));
 		});
 	});

--- a/src/maybe.test.ts
+++ b/src/maybe.test.ts
@@ -126,9 +126,9 @@ describe("Maybe", () => {
 
 		it("executes the finally block if Nothing is yielded in the try block", () => {
 			const logs: string[] = [];
-			function* f(): Maybe.Go<number> {
+			function* f(): Maybe.Go<1> {
 				try {
-					return yield* nothing<number>();
+					return yield* nothing<1>();
 				} finally {
 					logs.push("finally");
 				}
@@ -139,11 +139,11 @@ describe("Maybe", () => {
 		});
 
 		it("returns Nothing if Nothing is yielded in the finally block", () => {
-			function* f(): Maybe.Go<number> {
+			function* f(): Maybe.Go<1> {
 				try {
 					return 1;
 				} finally {
-					yield* nothing<number>();
+					yield* nothing<1>();
 				}
 			}
 			const maybe = Maybe.go(f());
@@ -226,9 +226,9 @@ describe("Maybe", () => {
 
 		it("executes the finally block if Nothing is yielded in the try block", async () => {
 			const logs: string[] = [];
-			async function* f(): Maybe.GoAsync<number> {
+			async function* f(): Maybe.GoAsync<1> {
 				try {
-					return yield* await Promise.resolve(nothing<number>());
+					return yield* await Promise.resolve(nothing<1>());
 				} finally {
 					logs.push("finally");
 				}
@@ -239,11 +239,11 @@ describe("Maybe", () => {
 		});
 
 		it("returns Nothing if Nothing is yielded in the finally block", async () => {
-			async function* f(): Maybe.GoAsync<number> {
+			async function* f(): Maybe.GoAsync<1> {
 				try {
 					return 1;
 				} finally {
-					yield* await Promise.resolve(nothing<number>());
+					yield* await Promise.resolve(nothing<1>());
 				}
 			}
 			const maybe = await Maybe.goAsync(f());

--- a/src/maybe.test.ts
+++ b/src/maybe.test.ts
@@ -29,11 +29,11 @@ import { cmb } from "./cmb.js";
 import { Ordering, cmp, eq } from "./cmp.js";
 import { Maybe } from "./maybe.js";
 
-function nothing<T>(): Maybe<T> {
-	return Maybe.nothing;
-}
-
 describe("Maybe", () => {
+	function nothing<T>(): Maybe<T> {
+		return Maybe.nothing;
+	}
+
 	function arbMaybe<T>(arbVal: fc.Arbitrary<T>): fc.Arbitrary<Maybe<T>> {
 		return fc.oneof(fc.constant(Maybe.nothing), arbVal.map(Maybe.just));
 	}
@@ -91,13 +91,13 @@ describe("Maybe", () => {
 
 	describe("wrapPred", () => {
 		it("adapts the predicate to return Nothing if not satisfied", () => {
-			const f = Maybe.wrapPred((x: number) => x === 1);
+			const f = Maybe.wrapPred((num: number) => num === 1);
 			const maybe = f(2);
 			expect(maybe).to.equal(Maybe.nothing);
 		});
 
 		it("adapts the predicate to return its argument in a Just if satisfied", () => {
-			const f = Maybe.wrapPred((x: number) => x === 1);
+			const f = Maybe.wrapPred((num: number) => num === 1);
 			const maybe = f(1);
 			expect(maybe).to.deep.equal(Maybe.just(1));
 		});
@@ -105,33 +105,30 @@ describe("Maybe", () => {
 
 	describe("go", () => {
 		it("short-circuits on the first yielded Nothing", () => {
-			function* f(): Maybe.Go<[1, 1, 2]> {
-				const x = yield* Maybe.just<1>(1);
-				const [y, z] = yield* nothing<[1, 2]>();
-				return [x, y, z];
+			function* f(): Maybe.Go<[1, 2]> {
+				const one = yield* Maybe.just<1>(1);
+				const two = yield* nothing<2>();
+				return [one, two];
 			}
 			const maybe = Maybe.go(f());
 			expect(maybe).to.equal(Maybe.nothing);
 		});
 
 		it("completes if all yielded values are Just", () => {
-			function* f(): Maybe.Go<[1, 1, 2]> {
-				const x = yield* Maybe.just<1>(1);
-				const [y, z] = yield* Maybe.just<[1, 2]>([x, 2]);
-				return [x, y, z];
+			function* f(): Maybe.Go<[1, 2]> {
+				const one = yield* Maybe.just<1>(1);
+				const two = yield* Maybe.just<2>(2);
+				return [one, two];
 			}
 			const maybe = Maybe.go(f());
-			expect(maybe).to.deep.equal(Maybe.just([1, 1, 2]));
+			expect(maybe).to.deep.equal(Maybe.just([1, 2]));
 		});
 
 		it("executes the finally block if Nothing is yielded in the try block", () => {
 			const logs: string[] = [];
-			function* f(): Maybe.Go<number[]> {
+			function* f(): Maybe.Go<number> {
 				try {
-					const results = [];
-					const x = yield* nothing<1>();
-					results.push(x);
-					return results;
+					return yield* nothing<number>();
 				} finally {
 					logs.push("finally");
 				}
@@ -142,11 +139,11 @@ describe("Maybe", () => {
 		});
 
 		it("returns Nothing if Nothing is yielded in the finally block", () => {
-			function* f(): Maybe.Go<number[]> {
+			function* f(): Maybe.Go<number> {
 				try {
-					return [1];
+					return 1;
 				} finally {
-					yield* nothing<1>();
+					yield* nothing<number>();
 				}
 			}
 			const maybe = Maybe.go(f());
@@ -158,7 +155,7 @@ describe("Maybe", () => {
 		it("reduces the finite iterable from left to right in the context of Maybe", () => {
 			const maybe = Maybe.reduce(
 				["x", "y"],
-				(xs, x) => Maybe.just(xs + x),
+				(chars, char) => Maybe.just(chars + char),
 				"",
 			);
 			expect(maybe).to.deep.equal(Maybe.just("xy"));
@@ -175,10 +172,10 @@ describe("Maybe", () => {
 	describe("allProps", () => {
 		it("turns the record or the object literal of Maybe elements inside out", () => {
 			const maybe = Maybe.allProps({
-				x: Maybe.just<1>(1),
-				y: Maybe.just<2>(2),
+				one: Maybe.just<1>(1),
+				two: Maybe.just<2>(2),
 			});
-			expect(maybe).to.deep.equal(Maybe.just({ x: 1, y: 2 }));
+			expect(maybe).to.deep.equal(Maybe.just({ one: 1, two: 2 }));
 		});
 	});
 
@@ -194,49 +191,44 @@ describe("Maybe", () => {
 
 	describe("goAsync", async () => {
 		it("short-circuits on the first yielded Nothing", async () => {
-			async function* f(): Maybe.GoAsync<[1, 1, 2]> {
-				const x = yield* await Promise.resolve(Maybe.just<1>(1));
-				const [y, z] = yield* await Promise.resolve(nothing<[1, 2]>());
-				return [x, y, z];
+			async function* f(): Maybe.GoAsync<[1, 2]> {
+				const one = yield* await Promise.resolve(Maybe.just<1>(1));
+				const two = yield* await Promise.resolve(nothing<2>());
+				return [one, two];
 			}
 			const maybe = await Maybe.goAsync(f());
 			expect(maybe).to.equal(Maybe.nothing);
 		});
 
 		it("completes if all yielded values are Just", async () => {
-			async function* f(): Maybe.GoAsync<[1, 1, 2]> {
-				const x = yield* await Promise.resolve(Maybe.just<1>(1));
-				const [y, z] = yield* await Promise.resolve(
-					Maybe.just<[1, 2]>([x, 2]),
-				);
-				return [x, y, z];
+			async function* f(): Maybe.GoAsync<[1, 2]> {
+				const one = yield* await Promise.resolve(Maybe.just<1>(1));
+				const two = yield* await Promise.resolve(Maybe.just<2>(2));
+				return [one, two];
 			}
 			const maybe = await Maybe.goAsync(f());
-			expect(maybe).to.deep.equal(Maybe.just([1, 1, 2]));
+			expect(maybe).to.deep.equal(Maybe.just([1, 2]));
 		});
 
 		it("unwraps Promises in Just variants and in return", async () => {
-			async function* f(): Maybe.GoAsync<[1, 1, 2]> {
-				const x = yield* await Promise.resolve(
+			async function* f(): Maybe.GoAsync<[1, 2]> {
+				const one = yield* await Promise.resolve(
 					Maybe.just(Promise.resolve<1>(1)),
 				);
-				const [y, z] = yield* await Promise.resolve(
-					Maybe.just(Promise.resolve<[1, 2]>([x, 2])),
+				const two = yield* await Promise.resolve(
+					Maybe.just(Promise.resolve<2>(2)),
 				);
-				return Promise.resolve([x, y, z]);
+				return Promise.resolve([one, two]);
 			}
 			const maybe = await Maybe.goAsync(f());
-			expect(maybe).to.deep.equal(Maybe.just([1, 1, 2]));
+			expect(maybe).to.deep.equal(Maybe.just([1, 2]));
 		});
 
 		it("executes the finally block if Nothing is yielded in the try block", async () => {
 			const logs: string[] = [];
-			async function* f(): Maybe.GoAsync<number[]> {
+			async function* f(): Maybe.GoAsync<number> {
 				try {
-					const results = [];
-					const x = yield* await Promise.resolve(nothing<1>());
-					results.push(x);
-					return results;
+					return yield* await Promise.resolve(nothing<number>());
 				} finally {
 					logs.push("finally");
 				}
@@ -247,11 +239,11 @@ describe("Maybe", () => {
 		});
 
 		it("returns Nothing if Nothing is yielded in the finally block", async () => {
-			async function* f(): Maybe.GoAsync<number[]> {
+			async function* f(): Maybe.GoAsync<number> {
 				try {
-					return [1];
+					return 1;
 				} finally {
-					yield* nothing<1>();
+					yield* await Promise.resolve(nothing<number>());
 				}
 			}
 			const maybe = await Maybe.goAsync(f());
@@ -266,24 +258,26 @@ describe("Maybe", () => {
 
 		it("compares Nothing and any Just as inequal", () => {
 			fc.assert(
-				fc.property(arbNum(), (y) => {
-					expect(eq(Maybe.nothing, Maybe.just(y))).to.be.false;
+				fc.property(arbNum(), (rhs) => {
+					expect(eq(Maybe.nothing, Maybe.just(rhs))).to.be.false;
 				}),
 			);
 		});
 
 		it("compares any Just and Nothing as inequal", () => {
 			fc.assert(
-				fc.property(arbNum(), (x) => {
-					expect(eq(Maybe.just(x), Maybe.nothing)).to.be.false;
+				fc.property(arbNum(), (lhs) => {
+					expect(eq(Maybe.just(lhs), Maybe.nothing)).to.be.false;
 				}),
 			);
 		});
 
 		it("compares the values if both variants are Just", () => {
 			fc.assert(
-				fc.property(arbNum(), arbNum(), (x, y) => {
-					expect(eq(Maybe.just(x), Maybe.just(y))).to.equal(eq(x, y));
+				fc.property(arbNum(), arbNum(), (lhs, rhs) => {
+					expect(eq(Maybe.just(lhs), Maybe.just(rhs))).to.equal(
+						eq(lhs, rhs),
+					);
 				}),
 			);
 		});
@@ -302,8 +296,8 @@ describe("Maybe", () => {
 
 		it("compares Nothing as less than any Just", () => {
 			fc.assert(
-				fc.property(arbNum(), (y) => {
-					expect(cmp(Maybe.nothing, Maybe.just(y))).to.equal(
+				fc.property(arbNum(), (rhs) => {
+					expect(cmp(Maybe.nothing, Maybe.just(rhs))).to.equal(
 						Ordering.less,
 					);
 				}),
@@ -312,8 +306,8 @@ describe("Maybe", () => {
 
 		it("compares any Just as greater than Nothing", () => {
 			fc.assert(
-				fc.property(arbNum(), (x) => {
-					expect(cmp(Maybe.just(x), Maybe.nothing)).to.equal(
+				fc.property(arbNum(), (lhs) => {
+					expect(cmp(Maybe.just(lhs), Maybe.nothing)).to.equal(
 						Ordering.greater,
 					);
 				}),
@@ -322,9 +316,9 @@ describe("Maybe", () => {
 
 		it("compares the values if both variants are Just", () => {
 			fc.assert(
-				fc.property(arbNum(), arbNum(), (x, y) => {
-					expect(cmp(Maybe.just(x), Maybe.just(y))).to.equal(
-						cmp(x, y),
+				fc.property(arbNum(), arbNum(), (lhs, rhs) => {
+					expect(cmp(Maybe.just(lhs), Maybe.just(rhs))).to.equal(
+						cmp(lhs, rhs),
 					);
 				}),
 			);
@@ -344,9 +338,9 @@ describe("Maybe", () => {
 
 		it("keeps the second Just if the first variant is Nothing", () => {
 			fc.assert(
-				fc.property(arbStr(), (y) => {
-					expect(cmb(Maybe.nothing, Maybe.just(y))).to.deep.equal(
-						Maybe.just(y),
+				fc.property(arbStr(), (rhs) => {
+					expect(cmb(Maybe.nothing, Maybe.just(rhs))).to.deep.equal(
+						Maybe.just(rhs),
 					);
 				}),
 			);
@@ -354,9 +348,9 @@ describe("Maybe", () => {
 
 		it("keeps the first Just if the second variant is Nothing", () => {
 			fc.assert(
-				fc.property(arbStr(), (x) => {
-					expect(cmb(Maybe.just(x), Maybe.nothing)).to.deep.equal(
-						Maybe.just(x),
+				fc.property(arbStr(), (lhs) => {
+					expect(cmb(Maybe.just(lhs), Maybe.nothing)).to.deep.equal(
+						Maybe.just(lhs),
 					);
 				}),
 			);
@@ -364,9 +358,9 @@ describe("Maybe", () => {
 
 		it("combines the values if both variants are Just", () => {
 			fc.assert(
-				fc.property(arbStr(), arbStr(), (x, y) => {
-					expect(cmb(Maybe.just(x), Maybe.just(y))).to.deep.equal(
-						Maybe.just(cmb(x, y)),
+				fc.property(arbStr(), arbStr(), (lhs, rhs) => {
+					expect(cmb(Maybe.just(lhs), Maybe.just(rhs))).to.deep.equal(
+						Maybe.just(cmb(lhs, rhs)),
 					);
 				}),
 			);
@@ -400,18 +394,18 @@ describe("Maybe", () => {
 	describe("#unwrap", () => {
 		it("evaluates the first function if the variant is Nothing", () => {
 			const result = nothing<1>().unwrap(
-				(): 2 => 2,
-				(x): [1, 3] => [x, 3],
+				(): 3 => 3,
+				(one): [1, 2] => [one, 2],
 			);
-			expect(result).to.equal(2);
+			expect(result).to.equal(3);
 		});
 
 		it("applies the second function to the value if the variant is Just", () => {
 			const result = Maybe.just<1>(1).unwrap(
-				(): 2 => 2,
-				(x): [1, 3] => [x, 3],
+				(): 3 => 3,
+				(one): [1, 2] => [one, 2],
 			);
-			expect(result).to.deep.equal([1, 3]);
+			expect(result).to.deep.equal([1, 2]);
 		});
 	});
 
@@ -466,14 +460,14 @@ describe("Maybe", () => {
 	describe("#flatMap", () => {
 		it("does not apply the continuation if the variant is Nothing", () => {
 			const maybe = nothing<1>().flatMap(
-				(x): Maybe<[1, 2]> => Maybe.just([x, 2]),
+				(one): Maybe<[1, 2]> => Maybe.just([one, 2]),
 			);
 			expect(maybe).to.equal(Maybe.nothing);
 		});
 
 		it("applies the continuation to the value if the variant is Just", () => {
 			const maybe = Maybe.just<1>(1).flatMap(
-				(x): Maybe<[1, 2]> => Maybe.just([x, 2]),
+				(one): Maybe<[1, 2]> => Maybe.just([one, 2]),
 			);
 			expect(maybe).to.deep.equal(Maybe.just([1, 2]));
 		});
@@ -481,17 +475,19 @@ describe("Maybe", () => {
 
 	describe("#goMap", () => {
 		it("does not apply the continuation if the variant is Nothing", () => {
-			const maybe = nothing<1>().goMap(function* (x) {
-				const y = yield* Maybe.just<2>(2);
-				return [x, y] as [1, 2];
+			const maybe = nothing<1>().goMap(function* (one): Maybe.Go<[1, 2]> {
+				const two = yield* Maybe.just<2>(2);
+				return [one, two];
 			});
 			expect(maybe).to.equal(Maybe.nothing);
 		});
 
 		it("applies the continuation to the value if the variant is Just", () => {
-			const maybe = Maybe.just<1>(1).goMap(function* (x) {
-				const y = yield* Maybe.just<2>(2);
-				return [x, y] as [1, 2];
+			const maybe = Maybe.just<1>(1).goMap(function* (
+				one,
+			): Maybe.Go<[1, 2]> {
+				const two = yield* Maybe.just<2>(2);
+				return [one, two];
 			});
 			expect(maybe).to.deep.equal(Maybe.just([1, 2]));
 		});
@@ -499,7 +495,10 @@ describe("Maybe", () => {
 
 	describe("#mapNullish", () => {
 		it("does not apply the continuation if the variant is Nothing", () => {
-			const maybe = nothing<1>().mapNullish((x): [1, 2] | null => [x, 2]);
+			const maybe = nothing<1>().mapNullish((one): [1, 2] | null => [
+				one,
+				2,
+			]);
 			expect(maybe).to.equal(Maybe.nothing);
 		});
 
@@ -519,7 +518,7 @@ describe("Maybe", () => {
 
 		it("returns the result in a Just if the continuation returns a non-null result", () => {
 			const maybe = Maybe.just<1>(1).mapNullish(
-				(x): [1, 2] | null | undefined => [x, 2],
+				(one): [1, 2] | null | undefined => [one, 2],
 			);
 			expect(maybe).to.deep.equal(Maybe.just([1, 2]));
 		});
@@ -527,17 +526,17 @@ describe("Maybe", () => {
 
 	describe("#filter", () => {
 		it("does not apply the predicate if the variant is Nothing", () => {
-			const maybe = nothing<number>().filter((x) => x === 1);
+			const maybe = nothing<number>().filter((one) => one === 1);
 			expect(maybe).to.equal(Maybe.nothing);
 		});
 
 		it("returns Nothing if the predicate returns false", () => {
-			const maybe = Maybe.just(1).filter((x) => x === 2);
+			const maybe = Maybe.just(1).filter((one) => one === 2);
 			expect(maybe).to.equal(Maybe.nothing);
 		});
 
 		it("returns the value in a Just if the predicate returns true", () => {
-			const maybe = Maybe.just(1).filter((x) => x === 1);
+			const maybe = Maybe.just(1).filter((one) => one === 1);
 			expect(maybe).to.deep.equal(Maybe.just(1));
 		});
 	});
@@ -546,7 +545,7 @@ describe("Maybe", () => {
 		it("applies the function to the values if both variants are Just", () => {
 			const maybe = Maybe.just<1>(1).zipWith(
 				Maybe.just<2>(2),
-				(lhs, rhs): [1, 2] => [lhs, rhs],
+				(one, two): [1, 2] => [one, two],
 			);
 			expect(maybe).to.deep.equal(Maybe.just([1, 2]));
 		});
@@ -568,7 +567,7 @@ describe("Maybe", () => {
 
 	describe("#map", () => {
 		it("applies the function to the value if the variant is Just", () => {
-			const maybe = Maybe.just<1>(1).map((x): [1, 2] => [x, 2]);
+			const maybe = Maybe.just<1>(1).map((one): [1, 2] => [one, 2]);
 			expect(maybe).to.deep.equal(Maybe.just([1, 2]));
 		});
 	});

--- a/src/maybe.test.ts
+++ b/src/maybe.test.ts
@@ -257,29 +257,26 @@ describe("Maybe", () => {
 		});
 
 		it("compares Nothing and any Just as inequal", () => {
-			fc.assert(
-				fc.property(arbNum(), (rhs) => {
-					expect(eq(Maybe.nothing, Maybe.just(rhs))).to.be.false;
-				}),
-			);
+			const property = fc.property(arbNum(), (rhs) => {
+				expect(eq(Maybe.nothing, Maybe.just(rhs))).to.be.false;
+			});
+			fc.assert(property);
 		});
 
 		it("compares any Just and Nothing as inequal", () => {
-			fc.assert(
-				fc.property(arbNum(), (lhs) => {
-					expect(eq(Maybe.just(lhs), Maybe.nothing)).to.be.false;
-				}),
-			);
+			const property = fc.property(arbNum(), (lhs) => {
+				expect(eq(Maybe.just(lhs), Maybe.nothing)).to.be.false;
+			});
+			fc.assert(property);
 		});
 
 		it("compares the values if both variants are Just", () => {
-			fc.assert(
-				fc.property(arbNum(), arbNum(), (lhs, rhs) => {
-					expect(eq(Maybe.just(lhs), Maybe.just(rhs))).to.equal(
-						eq(lhs, rhs),
-					);
-				}),
-			);
+			const property = fc.property(arbNum(), arbNum(), (lhs, rhs) => {
+				expect(eq(Maybe.just(lhs), Maybe.just(rhs))).to.equal(
+					eq(lhs, rhs),
+				);
+			});
+			fc.assert(property);
 		});
 
 		it("implements a lawful equivalence relation", () => {
@@ -295,33 +292,30 @@ describe("Maybe", () => {
 		});
 
 		it("compares Nothing as less than any Just", () => {
-			fc.assert(
-				fc.property(arbNum(), (rhs) => {
-					expect(cmp(Maybe.nothing, Maybe.just(rhs))).to.equal(
-						Ordering.less,
-					);
-				}),
-			);
+			const property = fc.property(arbNum(), (rhs) => {
+				expect(cmp(Maybe.nothing, Maybe.just(rhs))).to.equal(
+					Ordering.less,
+				);
+			});
+			fc.assert(property);
 		});
 
 		it("compares any Just as greater than Nothing", () => {
-			fc.assert(
-				fc.property(arbNum(), (lhs) => {
-					expect(cmp(Maybe.just(lhs), Maybe.nothing)).to.equal(
-						Ordering.greater,
-					);
-				}),
-			);
+			const property = fc.property(arbNum(), (lhs) => {
+				expect(cmp(Maybe.just(lhs), Maybe.nothing)).to.equal(
+					Ordering.greater,
+				);
+			});
+			fc.assert(property);
 		});
 
 		it("compares the values if both variants are Just", () => {
-			fc.assert(
-				fc.property(arbNum(), arbNum(), (lhs, rhs) => {
-					expect(cmp(Maybe.just(lhs), Maybe.just(rhs))).to.equal(
-						cmp(lhs, rhs),
-					);
-				}),
-			);
+			const property = fc.property(arbNum(), arbNum(), (lhs, rhs) => {
+				expect(cmp(Maybe.just(lhs), Maybe.just(rhs))).to.equal(
+					cmp(lhs, rhs),
+				);
+			});
+			fc.assert(property);
 		});
 
 		it("implements a lawful total order", () => {
@@ -337,33 +331,30 @@ describe("Maybe", () => {
 		});
 
 		it("keeps the second Just if the first variant is Nothing", () => {
-			fc.assert(
-				fc.property(arbStr(), (rhs) => {
-					expect(cmb(Maybe.nothing, Maybe.just(rhs))).to.deep.equal(
-						Maybe.just(rhs),
-					);
-				}),
-			);
+			const property = fc.property(arbStr(), (rhs) => {
+				expect(cmb(Maybe.nothing, Maybe.just(rhs))).to.deep.equal(
+					Maybe.just(rhs),
+				);
+			});
+			fc.assert(property);
 		});
 
 		it("keeps the first Just if the second variant is Nothing", () => {
-			fc.assert(
-				fc.property(arbStr(), (lhs) => {
-					expect(cmb(Maybe.just(lhs), Maybe.nothing)).to.deep.equal(
-						Maybe.just(lhs),
-					);
-				}),
-			);
+			const property = fc.property(arbStr(), (lhs) => {
+				expect(cmb(Maybe.just(lhs), Maybe.nothing)).to.deep.equal(
+					Maybe.just(lhs),
+				);
+			});
+			fc.assert(property);
 		});
 
 		it("combines the values if both variants are Just", () => {
-			fc.assert(
-				fc.property(arbStr(), arbStr(), (lhs, rhs) => {
-					expect(cmb(Maybe.just(lhs), Maybe.just(rhs))).to.deep.equal(
-						Maybe.just(cmb(lhs, rhs)),
-					);
-				}),
-			);
+			const property = fc.property(arbStr(), arbStr(), (lhs, rhs) => {
+				expect(cmb(Maybe.just(lhs), Maybe.just(rhs))).to.deep.equal(
+					Maybe.just(cmb(lhs, rhs)),
+				);
+			});
+			fc.assert(property);
 		});
 
 		it("implements a lawful semigroup", () => {

--- a/src/pair.test.ts
+++ b/src/pair.test.ts
@@ -32,7 +32,7 @@ describe("Pair", () => {
 		arbFst: fc.Arbitrary<A>,
 		arbSnd: fc.Arbitrary<B>,
 	): fc.Arbitrary<Pair<A, B>> {
-		return arbFst.chain((x) => arbSnd.map((y) => new Pair(x, y)));
+		return arbFst.chain((fst) => arbSnd.map((snd) => new Pair(fst, snd)));
 	}
 
 	describe("constructor", () => {
@@ -60,10 +60,10 @@ describe("Pair", () => {
 					arbNum(),
 					arbNum(),
 					arbNum(),
-					(a, x, b, y) => {
-						expect(eq(new Pair(a, x), new Pair(b, y))).to.equal(
-							eq(a, b) && eq(x, y),
-						);
+					(lhs0, lhs1, rhs0, rhs1) => {
+						expect(
+							eq(new Pair(lhs0, lhs1), new Pair(rhs0, rhs1)),
+						).to.equal(eq(lhs0, rhs0) && eq(lhs1, rhs1));
 					},
 				),
 			);
@@ -82,10 +82,10 @@ describe("Pair", () => {
 					arbNum(),
 					arbNum(),
 					arbNum(),
-					(a, x, b, y) => {
-						expect(cmp(new Pair(a, x), new Pair(b, y))).to.equal(
-							cmb(cmp(a, b), cmp(x, y)),
-						);
+					(lhs0, lhs1, rhs0, rhs1) => {
+						expect(
+							cmp(new Pair(lhs0, lhs1), new Pair(rhs0, rhs1)),
+						).to.equal(cmb(cmp(lhs0, rhs0), cmp(lhs1, rhs1)));
 					},
 				),
 			);
@@ -104,10 +104,12 @@ describe("Pair", () => {
 					arbStr(),
 					arbStr(),
 					arbStr(),
-					(a, x, b, y) => {
+					(lhs0, lhs1, rhs0, rhs1) => {
 						expect(
-							cmb(new Pair(a, x), new Pair(b, y)),
-						).to.deep.equal(new Pair(cmb(a, b), cmb(x, y)));
+							cmb(new Pair(lhs0, lhs1), new Pair(rhs0, rhs1)),
+						).to.deep.equal(
+							new Pair(cmb(lhs0, rhs0), cmb(lhs1, rhs1)),
+						);
 					},
 				),
 			);
@@ -120,9 +122,9 @@ describe("Pair", () => {
 
 	describe("#unwrap", () => {
 		it("applies the function to the first value and the second value", () => {
-			const result = new Pair<1, 2>(1, 2).unwrap((fst, snd): [1, 2] => [
-				fst,
-				snd,
+			const result = new Pair<1, 2>(1, 2).unwrap((one, two): [1, 2] => [
+				one,
+				two,
 			]);
 			expect(result).to.deep.equal([1, 2]);
 		});
@@ -130,14 +132,14 @@ describe("Pair", () => {
 
 	describe("#lmap", () => {
 		it("applies the function to the first value", () => {
-			const pair = new Pair<1, 2>(1, 2).lmap((x): [1, 3] => [x, 3]);
+			const pair = new Pair<1, 2>(1, 2).lmap((one): [1, 3] => [one, 3]);
 			expect(pair).to.deep.equal(new Pair([1, 3], 2));
 		});
 	});
 
 	describe("#map", () => {
 		it("applies the function to the second value", () => {
-			const pair = new Pair<1, 2>(1, 2).map((x): [2, 4] => [x, 4]);
+			const pair = new Pair<1, 2>(1, 2).map((two): [2, 4] => [two, 4]);
 			expect(pair).to.deep.equal(new Pair(1, [2, 4]));
 		});
 	});

--- a/src/pair.test.ts
+++ b/src/pair.test.ts
@@ -54,19 +54,18 @@ describe("Pair", () => {
 
 	describe("#[Eq.eq]", () => {
 		it("compares the first values and the second values lexicographically", () => {
-			fc.assert(
-				fc.property(
-					arbNum(),
-					arbNum(),
-					arbNum(),
-					arbNum(),
-					(lhs0, lhs1, rhs0, rhs1) => {
-						expect(
-							eq(new Pair(lhs0, lhs1), new Pair(rhs0, rhs1)),
-						).to.equal(eq(lhs0, rhs0) && eq(lhs1, rhs1));
-					},
-				),
+			const property = fc.property(
+				arbNum(),
+				arbNum(),
+				arbNum(),
+				arbNum(),
+				(lhs0, lhs1, rhs0, rhs1) => {
+					expect(
+						eq(new Pair(lhs0, lhs1), new Pair(rhs0, rhs1)),
+					).to.equal(eq(lhs0, rhs0) && eq(lhs1, rhs1));
+				},
 			);
+			fc.assert(property);
 		});
 
 		it("implements a lawful equivalence relation", () => {
@@ -76,19 +75,18 @@ describe("Pair", () => {
 
 	describe("#[Ord.cmp]", () => {
 		it("compares the first values and the second values lexicographically", () => {
-			fc.assert(
-				fc.property(
-					arbNum(),
-					arbNum(),
-					arbNum(),
-					arbNum(),
-					(lhs0, lhs1, rhs0, rhs1) => {
-						expect(
-							cmp(new Pair(lhs0, lhs1), new Pair(rhs0, rhs1)),
-						).to.equal(cmb(cmp(lhs0, rhs0), cmp(lhs1, rhs1)));
-					},
-				),
+			const property = fc.property(
+				arbNum(),
+				arbNum(),
+				arbNum(),
+				arbNum(),
+				(lhs0, lhs1, rhs0, rhs1) => {
+					expect(
+						cmp(new Pair(lhs0, lhs1), new Pair(rhs0, rhs1)),
+					).to.equal(cmb(cmp(lhs0, rhs0), cmp(lhs1, rhs1)));
+				},
 			);
+			fc.assert(property);
 		});
 
 		it("implements a lawful total order", () => {
@@ -98,21 +96,18 @@ describe("Pair", () => {
 
 	describe("#[Semigroup.cmb]", () => {
 		it("combines the first values and the second values pairwise", () => {
-			fc.assert(
-				fc.property(
-					arbStr(),
-					arbStr(),
-					arbStr(),
-					arbStr(),
-					(lhs0, lhs1, rhs0, rhs1) => {
-						expect(
-							cmb(new Pair(lhs0, lhs1), new Pair(rhs0, rhs1)),
-						).to.deep.equal(
-							new Pair(cmb(lhs0, rhs0), cmb(lhs1, rhs1)),
-						);
-					},
-				),
+			const property = fc.property(
+				arbStr(),
+				arbStr(),
+				arbStr(),
+				arbStr(),
+				(lhs0, lhs1, rhs0, rhs1) => {
+					expect(
+						cmb(new Pair(lhs0, lhs1), new Pair(rhs0, rhs1)),
+					).to.deep.equal(new Pair(cmb(lhs0, rhs0), cmb(lhs1, rhs1)));
+				},
 			);
+			fc.assert(property);
 		});
 
 		it("implements a lawful semigroup", () => {

--- a/src/validation.test.ts
+++ b/src/validation.test.ts
@@ -82,10 +82,10 @@ describe("Validation", () => {
 	describe("allProps", () => {
 		it("turns the record or the object literal of Validation elements inside out", () => {
 			const vdn = Validation.allProps({
-				x: Validation.ok<2, Str>(2),
-				y: Validation.ok<4, Str>(4),
+				two: Validation.ok<2, Str>(2),
+				four: Validation.ok<4, Str>(4),
 			});
-			expect(vdn).to.deep.equal(Validation.ok({ x: 2, y: 4 }));
+			expect(vdn).to.deep.equal(Validation.ok({ two: 2, four: 4 }));
 		});
 	});
 
@@ -105,35 +105,37 @@ describe("Validation", () => {
 	describe("#[Eq.eq]", () => {
 		it("compares the failures if both variants are Err", () => {
 			fc.assert(
-				fc.property(arbNum(), arbNum(), (x, y) => {
-					expect(eq(Validation.err(x), Validation.err(y))).to.equal(
-						eq(x, y),
-					);
+				fc.property(arbNum(), arbNum(), (lhs, rhs) => {
+					expect(
+						eq(Validation.err(lhs), Validation.err(rhs)),
+					).to.equal(eq(lhs, rhs));
 				}),
 			);
 		});
 
 		it("compares any Err and any Ok as inequal", () => {
 			fc.assert(
-				fc.property(arbNum(), arbNum(), (x, y) => {
-					expect(eq(Validation.err(x), Validation.ok(y))).to.be.false;
+				fc.property(arbNum(), arbNum(), (lhs, rhs) => {
+					expect(eq(Validation.err(lhs), Validation.ok(rhs))).to.be
+						.false;
 				}),
 			);
 		});
 
 		it("compares any Ok and any Err as inequal", () => {
 			fc.assert(
-				fc.property(arbNum(), arbNum(), (x, y) => {
-					expect(eq(Validation.ok(x), Validation.err(y))).to.be.false;
+				fc.property(arbNum(), arbNum(), (lhs, rhs) => {
+					expect(eq(Validation.ok(lhs), Validation.err(rhs))).to.be
+						.false;
 				}),
 			);
 		});
 
 		it("compares the successes if both variants are Ok", () => {
 			fc.assert(
-				fc.property(arbNum(), arbNum(), (x, y) => {
-					expect(eq(Validation.ok(x), Validation.ok(y))).to.equal(
-						eq(x, y),
+				fc.property(arbNum(), arbNum(), (lhs, rhs) => {
+					expect(eq(Validation.ok(lhs), Validation.ok(rhs))).to.equal(
+						eq(lhs, rhs),
 					);
 				}),
 			);
@@ -147,40 +149,40 @@ describe("Validation", () => {
 	describe("#[Ord.cmp]", () => {
 		it("compares the failures if both variants are Err", () => {
 			fc.assert(
-				fc.property(arbNum(), arbNum(), (x, y) => {
-					expect(cmp(Validation.err(x), Validation.err(y))).to.equal(
-						cmp(x, y),
-					);
+				fc.property(arbNum(), arbNum(), (lhs, rhs) => {
+					expect(
+						cmp(Validation.err(lhs), Validation.err(rhs)),
+					).to.equal(cmp(lhs, rhs));
 				}),
 			);
 		});
 
 		it("compares any Err as less than any Ok", () => {
 			fc.assert(
-				fc.property(arbNum(), arbNum(), (x, y) => {
-					expect(cmp(Validation.err(x), Validation.ok(y))).to.equal(
-						Ordering.less,
-					);
+				fc.property(arbNum(), arbNum(), (lhs, rhs) => {
+					expect(
+						cmp(Validation.err(lhs), Validation.ok(rhs)),
+					).to.equal(Ordering.less);
 				}),
 			);
 		});
 
 		it("compares any Ok as greater than any Err", () => {
 			fc.assert(
-				fc.property(arbNum(), arbNum(), (x, y) => {
-					expect(cmp(Validation.ok(x), Validation.err(y))).to.equal(
-						Ordering.greater,
-					);
+				fc.property(arbNum(), arbNum(), (lhs, rhs) => {
+					expect(
+						cmp(Validation.ok(lhs), Validation.err(rhs)),
+					).to.equal(Ordering.greater);
 				}),
 			);
 		});
 
 		it("compares the successes if both variants are Ok", () => {
 			fc.assert(
-				fc.property(arbNum(), arbNum(), (x, y) => {
-					expect(cmp(Validation.ok(x), Validation.ok(y))).to.equal(
-						cmp(x, y),
-					);
+				fc.property(arbNum(), arbNum(), (lhs, rhs) => {
+					expect(
+						cmp(Validation.ok(lhs), Validation.ok(rhs)),
+					).to.equal(cmp(lhs, rhs));
 				}),
 			);
 		});
@@ -193,10 +195,10 @@ describe("Validation", () => {
 	describe("#[Semigroup.cmb]", () => {
 		it("combines the successes if both variants are Ok", () => {
 			fc.assert(
-				fc.property(arbStr(), arbStr(), (x, y) => {
+				fc.property(arbStr(), arbStr(), (lhs, rhs) => {
 					expect(
-						cmb(Validation.ok(x), Validation.ok(y)),
-					).to.deep.equal(Validation.ok(cmb(x, y)));
+						cmb(Validation.ok(lhs), Validation.ok(rhs)),
+					).to.deep.equal(Validation.ok(cmb(lhs, rhs)));
 				}),
 			);
 		});
@@ -229,16 +231,16 @@ describe("Validation", () => {
 	describe("#unwrap", () => {
 		it("applies the first function to the failure if the variant is Err", () => {
 			const result = Validation.err<1, 2>(1).unwrap(
-				(x): [1, 3] => [x, 3],
-				(x): [2, 4] => [x, 4],
+				(one): [1, 3] => [one, 3],
+				(two): [2, 4] => [two, 4],
 			);
 			expect(result).to.deep.equal([1, 3]);
 		});
 
 		it("applies the second function to the success if the variant is Ok", () => {
 			const result = Validation.ok<2, 1>(2).unwrap(
-				(x): [1, 3] => [x, 3],
-				(x): [2, 4] => [x, 4],
+				(one): [1, 3] => [one, 3],
+				(two): [2, 4] => [two, 4],
 			);
 			expect(result).to.deep.equal([2, 4]);
 		});
@@ -248,7 +250,7 @@ describe("Validation", () => {
 		it("combines the failures if both variants are Err", () => {
 			const vdn = Validation.err<Str, 2>(new Str("a")).zipWith(
 				Validation.err<Str, 4>(new Str("b")),
-				(lhs, rhs): [2, 4] => [lhs, rhs],
+				(two, four): [2, 4] => [two, four],
 			);
 			expect(vdn).to.deep.equal(Validation.err(new Str("ab")));
 		});
@@ -256,7 +258,7 @@ describe("Validation", () => {
 		it("returns the first Err if the second variant is Ok", () => {
 			const vdn = Validation.err<Str, 2>(new Str("a")).zipWith(
 				Validation.ok<4, Str>(4),
-				(lhs, rhs): [2, 4] => [lhs, rhs],
+				(two, four): [2, 4] => [two, four],
 			);
 			expect(vdn).to.deep.equal(Validation.err(new Str("a")));
 		});
@@ -264,7 +266,7 @@ describe("Validation", () => {
 		it("returns the second Err if the first variant is Ok", () => {
 			const vdn = Validation.ok<2, Str>(2).zipWith(
 				Validation.err<Str, 4>(new Str("b")),
-				(lhs, rhs): [2, 4] => [lhs, rhs],
+				(two, four): [2, 4] => [two, four],
 			);
 			expect(vdn).to.deep.equal(Validation.err(new Str("b")));
 		});
@@ -272,7 +274,7 @@ describe("Validation", () => {
 		it("applies the function to the successes if both variants are Ok", () => {
 			const vdn = Validation.ok<2, Str>(2).zipWith(
 				Validation.ok<4, Str>(4),
-				(lhs, rhs): [2, 4] => [lhs, rhs],
+				(two, four): [2, 4] => [two, four],
 			);
 			expect(vdn).to.deep.equal(Validation.ok([2, 4]));
 		});
@@ -298,24 +300,24 @@ describe("Validation", () => {
 
 	describe("#lmap", () => {
 		it("applies the function to the failure if the variant is Err", () => {
-			const vdn = Validation.err<1, 2>(1).lmap((x): [1, 3] => [x, 3]);
+			const vdn = Validation.err<1, 2>(1).lmap((one): [1, 3] => [one, 3]);
 			expect(vdn).to.deep.equal(Validation.err([1, 3]));
 		});
 
 		it("does not apply the function if the variant is Ok", () => {
-			const vdn = Validation.ok<2, 1>(2).lmap((x): [1, 3] => [x, 3]);
+			const vdn = Validation.ok<2, 1>(2).lmap((one): [1, 3] => [one, 3]);
 			expect(vdn).to.deep.equal(Validation.ok(2));
 		});
 	});
 
 	describe("#map", () => {
 		it("does not apply the function if the variant is Err", () => {
-			const vdn = Validation.err<1, 2>(1).map((x): [2, 4] => [x, 4]);
+			const vdn = Validation.err<1, 2>(1).map((two): [2, 4] => [two, 4]);
 			expect(vdn).to.deep.equal(Validation.err(1));
 		});
 
 		it("applies the function to the success if the variant is Ok", () => {
-			const vdn = Validation.ok<2, 1>(2).map((x): [2, 4] => [x, 4]);
+			const vdn = Validation.ok<2, 1>(2).map((two): [2, 4] => [two, 4]);
 			expect(vdn).to.deep.equal(Validation.ok([2, 4]));
 		});
 	});

--- a/src/validation.test.ts
+++ b/src/validation.test.ts
@@ -104,41 +104,35 @@ describe("Validation", () => {
 
 	describe("#[Eq.eq]", () => {
 		it("compares the failures if both variants are Err", () => {
-			fc.assert(
-				fc.property(arbNum(), arbNum(), (lhs, rhs) => {
-					expect(
-						eq(Validation.err(lhs), Validation.err(rhs)),
-					).to.equal(eq(lhs, rhs));
-				}),
-			);
+			const property = fc.property(arbNum(), arbNum(), (lhs, rhs) => {
+				expect(eq(Validation.err(lhs), Validation.err(rhs))).to.equal(
+					eq(lhs, rhs),
+				);
+			});
+			fc.assert(property);
 		});
 
 		it("compares any Err and any Ok as inequal", () => {
-			fc.assert(
-				fc.property(arbNum(), arbNum(), (lhs, rhs) => {
-					expect(eq(Validation.err(lhs), Validation.ok(rhs))).to.be
-						.false;
-				}),
-			);
+			const property = fc.property(arbNum(), arbNum(), (lhs, rhs) => {
+				expect(eq(Validation.err(lhs), Validation.ok(rhs))).to.be.false;
+			});
+			fc.assert(property);
 		});
 
 		it("compares any Ok and any Err as inequal", () => {
-			fc.assert(
-				fc.property(arbNum(), arbNum(), (lhs, rhs) => {
-					expect(eq(Validation.ok(lhs), Validation.err(rhs))).to.be
-						.false;
-				}),
-			);
+			const property = fc.property(arbNum(), arbNum(), (lhs, rhs) => {
+				expect(eq(Validation.ok(lhs), Validation.err(rhs))).to.be.false;
+			});
+			fc.assert(property);
 		});
 
 		it("compares the successes if both variants are Ok", () => {
-			fc.assert(
-				fc.property(arbNum(), arbNum(), (lhs, rhs) => {
-					expect(eq(Validation.ok(lhs), Validation.ok(rhs))).to.equal(
-						eq(lhs, rhs),
-					);
-				}),
-			);
+			const property = fc.property(arbNum(), arbNum(), (lhs, rhs) => {
+				expect(eq(Validation.ok(lhs), Validation.ok(rhs))).to.equal(
+					eq(lhs, rhs),
+				);
+			});
+			fc.assert(property);
 		});
 
 		it("implements a lawful equivalence relation", () => {
@@ -148,43 +142,39 @@ describe("Validation", () => {
 
 	describe("#[Ord.cmp]", () => {
 		it("compares the failures if both variants are Err", () => {
-			fc.assert(
-				fc.property(arbNum(), arbNum(), (lhs, rhs) => {
-					expect(
-						cmp(Validation.err(lhs), Validation.err(rhs)),
-					).to.equal(cmp(lhs, rhs));
-				}),
-			);
+			const property = fc.property(arbNum(), arbNum(), (lhs, rhs) => {
+				expect(cmp(Validation.err(lhs), Validation.err(rhs))).to.equal(
+					cmp(lhs, rhs),
+				);
+			});
+			fc.assert(property);
 		});
 
 		it("compares any Err as less than any Ok", () => {
-			fc.assert(
-				fc.property(arbNum(), arbNum(), (lhs, rhs) => {
-					expect(
-						cmp(Validation.err(lhs), Validation.ok(rhs)),
-					).to.equal(Ordering.less);
-				}),
-			);
+			const property = fc.property(arbNum(), arbNum(), (lhs, rhs) => {
+				expect(cmp(Validation.err(lhs), Validation.ok(rhs))).to.equal(
+					Ordering.less,
+				);
+			});
+			fc.assert(property);
 		});
 
 		it("compares any Ok as greater than any Err", () => {
-			fc.assert(
-				fc.property(arbNum(), arbNum(), (lhs, rhs) => {
-					expect(
-						cmp(Validation.ok(lhs), Validation.err(rhs)),
-					).to.equal(Ordering.greater);
-				}),
-			);
+			const property = fc.property(arbNum(), arbNum(), (lhs, rhs) => {
+				expect(cmp(Validation.ok(lhs), Validation.err(rhs))).to.equal(
+					Ordering.greater,
+				);
+			});
+			fc.assert(property);
 		});
 
 		it("compares the successes if both variants are Ok", () => {
-			fc.assert(
-				fc.property(arbNum(), arbNum(), (lhs, rhs) => {
-					expect(
-						cmp(Validation.ok(lhs), Validation.ok(rhs)),
-					).to.equal(cmp(lhs, rhs));
-				}),
-			);
+			const property = fc.property(arbNum(), arbNum(), (lhs, rhs) => {
+				expect(cmp(Validation.ok(lhs), Validation.ok(rhs))).to.equal(
+					cmp(lhs, rhs),
+				);
+			});
+			fc.assert(property);
 		});
 
 		it("implements a lawful total order", () => {
@@ -194,13 +184,12 @@ describe("Validation", () => {
 
 	describe("#[Semigroup.cmb]", () => {
 		it("combines the successes if both variants are Ok", () => {
-			fc.assert(
-				fc.property(arbStr(), arbStr(), (lhs, rhs) => {
-					expect(
-						cmb(Validation.ok(lhs), Validation.ok(rhs)),
-					).to.deep.equal(Validation.ok(cmb(lhs, rhs)));
-				}),
-			);
+			const property = fc.property(arbStr(), arbStr(), (lhs, rhs) => {
+				expect(
+					cmb(Validation.ok(lhs), Validation.ok(rhs)),
+				).to.deep.equal(Validation.ok(cmb(lhs, rhs)));
+			});
+			fc.assert(property);
 		});
 
 		it("implements a lawful semigroup", () => {


### PR DESCRIPTION
- Choose better names for variables in all unit tests, e.g. prefer "lhs" and "rhs" over "x" and "y".
- Simplify the tests for generator comprehensions.
- Un-nest fast-check properties from fast-check assertions to reduce the amount of indentation.