### PR TITLE
Refactor methods for chaining and recovery

### DIFF
--- a/src/either.test.ts
+++ b/src/either.test.ts
@@ -355,41 +355,53 @@ describe("Either", () => {
 		});
 	});
 
-	describe("#recover", () => {
+	describe("#orElse", () => {
 		it("applies the continuation to the failure if the variant is Left", () => {
-			const either = Either.left<1, 2>(1).recover(
+			const either = Either.left<1, 2>(1).orElse(
 				(one): Either<[1, 3], 4> => Either.left([one, 3]),
 			);
 			expect(either).to.deep.equal(Either.left([1, 3]));
 		});
 
 		it("does not apply the continuation if the variant is Right", () => {
-			const either = Either.right<2, 1>(2).recover(
+			const either = Either.right<2, 1>(2).orElse(
 				(one): Either<[1, 3], 4> => Either.left([one, 3]),
 			);
 			expect(either).to.deep.equal(Either.right(2));
 		});
 	});
 
-	describe("#flatMap", () => {
+	describe("#or", () => {
+		it("returns the fallback Either if the variant is Left", () => {
+			const either = Either.left<1, 2>(1).or(Either.right<4, 3>(4));
+			expect(either).to.deep.equal(Either.right(4));
+		});
+
+		it("returns the original Either if the variant is Right", () => {
+			const either = Either.right<2, 1>(2).or(Either.right<4, 3>(4));
+			expect(either).to.deep.equal(Either.right(2));
+		});
+	});
+
+	describe("#andThen", () => {
 		it("does not apply the continuation if the variant is Left", () => {
-			const either = Either.left<1, 2>(1).flatMap(
+			const either = Either.left<1, 2>(1).andThen(
 				(two): Either<3, [2, 4]> => Either.right([two, 4]),
 			);
 			expect(either).to.deep.equal(Either.left(1));
 		});
 
 		it("applies the continuation to the success if the variant is Right", () => {
-			const either = Either.right<2, 1>(2).flatMap(
+			const either = Either.right<2, 1>(2).andThen(
 				(two): Either<3, [2, 4]> => Either.right([two, 4]),
 			);
 			expect(either).to.deep.equal(Either.right([2, 4]));
 		});
 	});
 
-	describe("#goMap", () => {
+	describe("#andThenGo", () => {
 		it("does not apply the continuation if the variant is Left", () => {
-			const either = Either.left<1, 2>(1).goMap(function* (
+			const either = Either.left<1, 2>(1).andThenGo(function* (
 				two,
 			): Either.Go<3, [2, 4]> {
 				const four = yield* Either.right<4, 3>(4);
@@ -399,13 +411,25 @@ describe("Either", () => {
 		});
 
 		it("applies the continuation to the success if the variant is Right", () => {
-			const either = Either.right<2, 1>(2).goMap(function* (
+			const either = Either.right<2, 1>(2).andThenGo(function* (
 				two,
 			): Either.Go<3, [2, 4]> {
 				const four = yield* Either.right<4, 3>(4);
 				return [two, four];
 			});
 			expect(either).to.deep.equal(Either.right([2, 4]));
+		});
+	});
+
+	describe("#and", () => {
+		it("returns the original Either if the variant is Left", () => {
+			const either = Either.left<1, 2>(1).and(Either.right<4, 3>(4));
+			expect(either).to.deep.equal(Either.left(1));
+		});
+
+		it("returns the other Either if the variant is Right", () => {
+			const either = Either.right<2, 1>(2).and(Either.right<4, 3>(4));
+			expect(either).to.deep.equal(Either.right(4));
 		});
 	});
 
@@ -416,13 +440,6 @@ describe("Either", () => {
 				(two, four): [2, 4] => [two, four],
 			);
 			expect(either).to.deep.equal(Either.right([2, 4]));
-		});
-	});
-
-	describe("#and", () => {
-		it("keeps only the second success if both variants are Right", () => {
-			const either = Either.right<2, 1>(2).and(Either.right<4, 3>(4));
-			expect(either).to.deep.equal(Either.right(4));
 		});
 	});
 

--- a/src/eval.test.ts
+++ b/src/eval.test.ts
@@ -172,9 +172,9 @@ describe("Eval", () => {
 		});
 	});
 
-	describe("#flatMap", () => {
+	describe("#andThen", () => {
 		it("applies the continuation to the outcome", () => {
-			const ev = Eval.now<1>(1).flatMap(
+			const ev = Eval.now<1>(1).andThen(
 				(one): Eval<[1, 2]> => Eval.now([one, 2]),
 			);
 			const outcome = ev.run();
@@ -182,14 +182,24 @@ describe("Eval", () => {
 		});
 	});
 
-	describe("#goMap", () => {
+	describe("#andThenGo", () => {
 		it("applies the continuation to the outcome", () => {
-			const ev = Eval.now<1>(1).goMap(function* (one): Eval.Go<[1, 2]> {
+			const ev = Eval.now<1>(1).andThenGo(function* (
+				one,
+			): Eval.Go<[1, 2]> {
 				const two = yield* Eval.now<2>(2);
 				return [one, two];
 			});
 			const outcome = ev.run();
 			expect(outcome).to.deep.equal([1, 2]);
+		});
+	});
+
+	describe("#and", () => {
+		it("returns the other Eval", () => {
+			const ev = Eval.now<1>(1).and(Eval.now<2>(2));
+			const outcome = ev.run();
+			expect(outcome).to.equal(2);
 		});
 	});
 
@@ -201,14 +211,6 @@ describe("Eval", () => {
 			);
 			const outcome = ev.run();
 			expect(outcome).to.deep.equal([1, 2]);
-		});
-	});
-
-	describe("#and", () => {
-		it("keeps only the second outcome", () => {
-			const ev = Eval.now<1>(1).and(Eval.now<2>(2));
-			const outcome = ev.run();
-			expect(outcome).to.equal(2);
 		});
 	});
 

--- a/src/ior.test.ts
+++ b/src/ior.test.ts
@@ -779,53 +779,53 @@ describe("Ior", () => {
 		});
 	});
 
-	describe("#flatMap", () => {
+	describe("#andThen", () => {
 		it("does not apply the continuation if the variant is Left", () => {
-			const ior = Ior.left<Str, 2>(new Str("a")).flatMap(
+			const ior = Ior.left<Str, 2>(new Str("a")).andThen(
 				(two): Ior<Str, [2, 4]> => Ior.both(new Str("b"), [two, 4]),
 			);
 			expect(ior).to.deep.equal(Ior.left(new Str("a")));
 		});
 
 		it("applies the continuation to the value if the variant is Right", () => {
-			const ior = Ior.right<2, Str>(2).flatMap(
+			const ior = Ior.right<2, Str>(2).andThen(
 				(two): Ior<Str, [2, 4]> => Ior.right([two, 4]),
 			);
 			expect(ior).to.deep.equal(Ior.right([2, 4]));
 		});
 
 		it("retains the left-hand value if the continuation on a Right returns a Both", () => {
-			const ior = Ior.right<2, Str>(2).flatMap(
+			const ior = Ior.right<2, Str>(2).andThen(
 				(two): Ior<Str, [2, 4]> => Ior.both(new Str("b"), [two, 4]),
 			);
 			expect(ior).to.deep.equal(Ior.both(new Str("b"), [2, 4]));
 		});
 
 		it("combines the left-hand values if the continuation on a Both returns a Left", () => {
-			const ior = Ior.both<Str, 2>(new Str("a"), 2).flatMap(
+			const ior = Ior.both<Str, 2>(new Str("a"), 2).andThen(
 				(): Ior<Str, [2, 4]> => Ior.left(new Str("b")),
 			);
 			expect(ior).to.deep.equal(Ior.left(new Str("ab")));
 		});
 
 		it("retains the left-hand value if the continuation on a Both returns a Right", () => {
-			const ior = Ior.both<Str, 2>(new Str("a"), 2).flatMap(
+			const ior = Ior.both<Str, 2>(new Str("a"), 2).andThen(
 				(two): Ior<Str, [2, 4]> => Ior.right([two, 4]),
 			);
 			expect(ior).to.deep.equal(Ior.both(new Str("a"), [2, 4]));
 		});
 
 		it("combines the left-hand values if the continuation on a Both returns a Both", () => {
-			const ior = Ior.both<Str, 2>(new Str("a"), 2).flatMap(
+			const ior = Ior.both<Str, 2>(new Str("a"), 2).andThen(
 				(two): Ior<Str, [2, 4]> => Ior.both(new Str("b"), [two, 4]),
 			);
 			expect(ior).to.deep.equal(Ior.both(new Str("ab"), [2, 4]));
 		});
 	});
 
-	describe("#goMap", () => {
+	describe("#andThenGo", () => {
 		it("does not apply the continuation if the variant is Left", () => {
-			const ior = Ior.left<Str, 2>(new Str("a")).goMap(function* (
+			const ior = Ior.left<Str, 2>(new Str("a")).andThenGo(function* (
 				two,
 			): Ior.Go<Str, [2, 4]> {
 				const four = yield* Ior.both<Str, 4>(new Str("b"), 4);
@@ -835,7 +835,7 @@ describe("Ior", () => {
 		});
 
 		it("applies the continuation to the value if the variant is Right", () => {
-			const ior = Ior.right<2, Str>(2).goMap(function* (
+			const ior = Ior.right<2, Str>(2).andThenGo(function* (
 				two,
 			): Ior.Go<Str, [2, 4]> {
 				const four = yield* Ior.right<4, Str>(4);
@@ -845,7 +845,7 @@ describe("Ior", () => {
 		});
 
 		it("retains the left-hand value if the continuation on a Right returns a Both", () => {
-			const ior = Ior.right<2, Str>(2).goMap(function* (
+			const ior = Ior.right<2, Str>(2).andThenGo(function* (
 				two,
 			): Ior.Go<Str, [2, 4]> {
 				const four = yield* Ior.both<Str, 4>(new Str("b"), 4);
@@ -855,7 +855,7 @@ describe("Ior", () => {
 		});
 
 		it("combines the left-hand values if the continuation on a Both returns a Left", () => {
-			const ior = Ior.both<Str, 2>(new Str("a"), 2).goMap(function* (
+			const ior = Ior.both<Str, 2>(new Str("a"), 2).andThenGo(function* (
 				two,
 			): Ior.Go<Str, [2, 4]> {
 				const four = yield* Ior.left<Str, 4>(new Str("b"));
@@ -865,7 +865,7 @@ describe("Ior", () => {
 		});
 
 		it("retains the left-hand value if the continuation on a Both returns a Right", () => {
-			const ior = Ior.both<Str, 2>(new Str("a"), 2).goMap(function* (
+			const ior = Ior.both<Str, 2>(new Str("a"), 2).andThenGo(function* (
 				two,
 			): Ior.Go<Str, [2, 4]> {
 				const four = yield* Ior.right<4, Str>(4);
@@ -875,22 +875,12 @@ describe("Ior", () => {
 		});
 
 		it("combines the left-hand values if the continuation on a Both returns a Both", () => {
-			const ior = Ior.both<Str, 2>(new Str("a"), 2).goMap(function* (
+			const ior = Ior.both<Str, 2>(new Str("a"), 2).andThenGo(function* (
 				two,
 			): Ior.Go<Str, [2, 4]> {
 				const four = yield* Ior.both<Str, 4>(new Str("b"), 4);
 				return [two, four];
 			});
-			expect(ior).to.deep.equal(Ior.both(new Str("ab"), [2, 4]));
-		});
-	});
-
-	describe("#zipWith", () => {
-		it("applies the function to the right-hand values if both variants have right-hand values", () => {
-			const ior = Ior.both<Str, 2>(new Str("a"), 2).zipWith(
-				Ior.both<Str, 4>(new Str("b"), 4),
-				(two, four): [2, 4] => [two, four],
-			);
 			expect(ior).to.deep.equal(Ior.both(new Str("ab"), [2, 4]));
 		});
 	});
@@ -901,6 +891,16 @@ describe("Ior", () => {
 				Ior.both<Str, 4>(new Str("b"), 4),
 			);
 			expect(ior).to.deep.equal(Ior.both(new Str("ab"), 4));
+		});
+	});
+
+	describe("#zipWith", () => {
+		it("applies the function to the right-hand values if both variants have right-hand values", () => {
+			const ior = Ior.both<Str, 2>(new Str("a"), 2).zipWith(
+				Ior.both<Str, 4>(new Str("b"), 4),
+				(two, four): [2, 4] => [two, four],
+			);
+			expect(ior).to.deep.equal(Ior.both(new Str("ab"), [2, 4]));
 		});
 	});
 

--- a/src/maybe.test.ts
+++ b/src/maybe.test.ts
@@ -436,37 +436,51 @@ describe("Maybe", () => {
 		});
 	});
 
-	describe("#recover", () => {
+	describe("#orElse", () => {
 		it("evaluates the function if the variant is Nothing", () => {
-			const maybe = nothing<1>().recover(() => Maybe.just<2>(2));
+			const maybe = nothing<1>().orElse(() => Maybe.just<2>(2));
 			expect(maybe).to.deep.equal(Maybe.just(2));
 		});
 
 		it("does not evaluate the function if the variant is Just", () => {
-			const maybe = Maybe.just<1>(1).recover(() => Maybe.just<2>(2));
+			const maybe = Maybe.just<1>(1).orElse(() => Maybe.just<2>(2));
 			expect(maybe).to.deep.equal(Maybe.just(1));
 		});
 	});
 
-	describe("#flatMap", () => {
+	describe("#or", () => {
+		it("returns the other Maybe if the variant is Nothing", () => {
+			const maybe = nothing<1>().or(Maybe.just<2>(2));
+			expect(maybe).to.deep.equal(Maybe.just(2));
+		});
+
+		it("returns the original Maybe if the variant is Just", () => {
+			const maybe = Maybe.just<1>(1).or(Maybe.just<2>(2));
+			expect(maybe).to.deep.equal(Maybe.just(1));
+		});
+	});
+
+	describe("#andThen", () => {
 		it("does not apply the continuation if the variant is Nothing", () => {
-			const maybe = nothing<1>().flatMap(
+			const maybe = nothing<1>().andThen(
 				(one): Maybe<[1, 2]> => Maybe.just([one, 2]),
 			);
 			expect(maybe).to.equal(Maybe.nothing);
 		});
 
 		it("applies the continuation to the value if the variant is Just", () => {
-			const maybe = Maybe.just<1>(1).flatMap(
+			const maybe = Maybe.just<1>(1).andThen(
 				(one): Maybe<[1, 2]> => Maybe.just([one, 2]),
 			);
 			expect(maybe).to.deep.equal(Maybe.just([1, 2]));
 		});
 	});
 
-	describe("#goMap", () => {
+	describe("#andThenGo", () => {
 		it("does not apply the continuation if the variant is Nothing", () => {
-			const maybe = nothing<1>().goMap(function* (one): Maybe.Go<[1, 2]> {
+			const maybe = nothing<1>().andThenGo(function* (
+				one,
+			): Maybe.Go<[1, 2]> {
 				const two = yield* Maybe.just<2>(2);
 				return [one, two];
 			});
@@ -474,13 +488,25 @@ describe("Maybe", () => {
 		});
 
 		it("applies the continuation to the value if the variant is Just", () => {
-			const maybe = Maybe.just<1>(1).goMap(function* (
+			const maybe = Maybe.just<1>(1).andThenGo(function* (
 				one,
 			): Maybe.Go<[1, 2]> {
 				const two = yield* Maybe.just<2>(2);
 				return [one, two];
 			});
 			expect(maybe).to.deep.equal(Maybe.just([1, 2]));
+		});
+	});
+
+	describe("#and", () => {
+		it("returns the original Maybe if the variant is Nothing", () => {
+			const maybe = nothing<1>().and(Maybe.just<2>(2));
+			expect(maybe).to.deep.equal(Maybe.nothing);
+		});
+
+		it("returns the other Maybe if the variant is Just", () => {
+			const maybe = Maybe.just<1>(1).and(Maybe.just<2>(2));
+			expect(maybe).to.deep.equal(Maybe.just(2));
 		});
 	});
 
@@ -539,13 +565,6 @@ describe("Maybe", () => {
 				(one, two): [1, 2] => [one, two],
 			);
 			expect(maybe).to.deep.equal(Maybe.just([1, 2]));
-		});
-	});
-
-	describe("#and", () => {
-		it("keeps only the second value if both variants are Just", () => {
-			const maybe = Maybe.just<1>(1).and(Maybe.just<2>(2));
-			expect(maybe).to.deep.equal(Maybe.just(2));
 		});
 	});
 

--- a/src/validation.test.ts
+++ b/src/validation.test.ts
@@ -235,6 +235,13 @@ describe("Validation", () => {
 		});
 	});
 
+	describe("#and", () => {
+		it("returns the other Validation if the variant is Ok", () => {
+			const vdn = Validation.ok<2, Str>(2).and(Validation.ok<4, Str>(4));
+			expect(vdn).to.deep.equal(Validation.ok(4));
+		});
+	});
+
 	describe("#zipWith", () => {
 		it("combines the failures if both variants are Err", () => {
 			const vdn = Validation.err<Str, 2>(new Str("a")).zipWith(
@@ -266,13 +273,6 @@ describe("Validation", () => {
 				(two, four): [2, 4] => [two, four],
 			);
 			expect(vdn).to.deep.equal(Validation.ok([2, 4]));
-		});
-	});
-
-	describe("#and", () => {
-		it("keeps only the second success if both variants are Ok", () => {
-			const vdn = Validation.ok<2, Str>(2).and(Validation.ok<4, Str>(4));
-			expect(vdn).to.deep.equal(Validation.ok(4));
 		});
 	});
 

--- a/src/validation.ts
+++ b/src/validation.ts
@@ -123,11 +123,14 @@
  * -   `lmap` applies a function to the failure.
  * -   `map` applies a function to the success.
  *
- * These methods combine the successes of two successful `Validation` values, or
- * begin accumulating failures on any failed `Validation`:
+ * ## Chaining `Validation`
  *
- * -   `zipWith` applies a function to their successes.
- * -   `and` keeps only the second success, and discards the first.
+ * These methods act on a successful `Validation` to produce another
+ * `Validation`:
+ *
+ * -   `and` ignores the success and returns another `Validation`.
+ * -   `zipWith` evaluates another `Validation`, and if successful, applies a
+ *     function to both successes.
  *
  * ## Collecting into `Validation`
  *
@@ -580,6 +583,17 @@ export namespace Validation {
 		}
 
 		/**
+		 * If this `Validation` succeeds, return that `Validation`; otherwise,
+		 * begin accumulating failures on this `Validation`.
+		 */
+		and<E extends Semigroup<E>, T1>(
+			this: Validation<E, any>,
+			that: Validation<E, T1>,
+		): Validation<E, T1> {
+			return this.zipWith(that, (_, rhs) => rhs);
+		}
+
+		/**
 		 * If this and that `Validation` both succeed, apply a function to their
 		 * successes and succeed with the result; otherwise, begin accumulating
 		 * failures on the first failed `Validation`.
@@ -593,17 +607,6 @@ export namespace Validation {
 				return that.isErr() ? err(cmb(this.val, that.val)) : this;
 			}
 			return that.isErr() ? that : ok(f(this.val, that.val));
-		}
-
-		/**
-		 * If this `Validation` succeeds, return that `Validation`; otherwise,
-		 * begin accumulating failures on this `Validation`.
-		 */
-		and<E extends Semigroup<E>, T1>(
-			this: Validation<E, any>,
-			that: Validation<E, T1>,
-		): Validation<E, T1> {
-			return this.zipWith(that, (_, rhs) => rhs);
 		}
 
 		/**


### PR DESCRIPTION
- Rename the `flatMap` methods to `andThen`
- Rename the `goMap` methods to `andThenGo`
- Rename the `recover` methods to `orElse`
- Introduce the `or` methods
- Reorganize the documentation for chaining and recovery